### PR TITLE
Add the start of an "Architecture" page in the docs

### DIFF
--- a/lib/mint/http.ex
+++ b/lib/mint/http.ex
@@ -79,7 +79,7 @@ defmodule Mint.HTTP do
   in a process that acts as *connection manager*. Sometimes, you might want to
   have a single process responsible for multiple connections, either to just one
   host or multiple hosts. For more discussion on architectures based off of this
-  HTTP client, see the [TODO architecture] page in the docs.
+  HTTP client, see the [*Architecture*](architecture.html) page in the docs.
   """
 
   import Mint.Core.Util

--- a/mix.exs
+++ b/mix.exs
@@ -21,7 +21,8 @@ defmodule Mint.MixProject do
       name: "Mint",
       docs: [
         source_ref: "v#{@version}",
-        source_url: @repo_url
+        source_url: @repo_url,
+        extras: ["pages/Architecture.md"]
       ]
     ]
   end

--- a/pages/Architecture.md
+++ b/pages/Architecture.md
@@ -1,0 +1,105 @@
+# Architecture
+
+Mint is an HTTP client with a process-less architecture. Mint provides an API where the HTTP connection is represented by a functional and immutable data structure, a **connection**. Every operation you do on the connection (like sending a request) returns an updated connection. A connection wraps a socket that is in active mode. Messages coming from the socket are delivered to the process that created the connection. You can hand those messages to Mint so that they can be parsed into responses.
+
+Having a process-less architecture makes Mint a powerful and composable HTTP client. The developer has more flexibility compared to a client that forces an interface that includes processes. A Mint connection can be stored inside any kind of process, such as GenServers or GenStage processes.
+
+Another important feature enabled by the Mint architecture is that a single process can store and manage multiple Mint connections since they are simple data structures. When a message comes from a socket, it's easy to identify which connection it belongs to since that's the only connection that will return a response different from `:unknown` when the messages are parsed. This enables developers to use Mint in fine-tailored ways that suit their needs.
+
+## Pooling
+
+The Mint connection architecture is low level. This means that it doesn't provide things like connection pooling out of the box. This is by design: it's hard to write a general purpose HTTP connection pool that fits all use cases and it's often better to write simple pools that better fit your own use case. In this page, we'll see a few possible uses of Mint including some simple connection pools that you can use as a base for writing your own.
+
+## Usage examples
+
+Let's see a few example of how to use Mint connections.
+
+### Wrapping a Mint connection in a GenServer
+
+In this example we will look at wrapping a single connection in a GenServer. This architecture can be useful if you only need to issue a few requests to the same host, or if you plan to have many connections spread over just as many processes.
+
+The way this architecture works is that a GenServer process holds the connection. The connection is started when the `ConnectionProcess` GenServer starts (in the `init/1` callback). When a request is made, the request is sent but the GenServer keeps processing stuff and doesn't directly reply to the process that asked to send the request. The GenServer will only reply to the caller once a response comes from the server. This allows the GenServer to keep sending requests and processing responses while making the request blocking for the caller.
+
+```elixir
+defmodule ConnectionProcess do
+  use GenServer
+
+  require Logger
+
+  defstruct [:conn, requests: %{}]
+
+  def start_link({scheme, host, port}) do
+    GenServer.start_link(__MODULE__, {scheme, host, port})
+  end
+
+  def request(pid, method, path, headers, body) do
+    GenServer.call(pid, {:request, method, path, headers, body})
+  end
+
+  ## Callbacks
+
+  @impl true
+  def init({scheme, host, port}) do
+    with {:ok, conn} <- Mint.HTTP.connect(scheme, host, port) do
+      state = %__MODULE__{conn: conn}
+      {:ok, state}
+    end
+  end
+
+  @impl true
+  def handle_call({:request, method, path, headers, body}, from, state) do
+    # In both the successful case and the error case, we make sure to update the connection
+    # struct in the state since the connection is an immutable data structure.
+    case Mint.HTTP.request(state.conn, method, path, headers, body) do
+      {:ok, request_ref, conn} ->
+        state = put_in(state.conn, conn)
+        # We store the caller this request belongs to and an empty map as the response.
+        # The map will be filled with status code, headers, and so on.
+        state = put_in(state.requests[request_ref], %{from: from, response: %{}})
+        {:noreply, state}
+
+      {:error, reason, conn} ->
+        state = put_in(state.conn, conn)
+        {:reply, {:error, reason}, state}
+    end
+  end
+
+  @impl true
+  def handle_info(message, state) do
+    # We should handle the error case here as well, but we're omitting it for brevity.
+    case Mint.HTTP.stream(state.conn, message) do
+      :unknown ->
+        Logger.error(fn -> "Received unknown message: " <> inspect(message) end)
+        {:noreply, state}
+
+      {:ok, conn, responses} ->
+        state = put_in(state.conn, conn)
+        state = Enum.reduce(responses, state, &process_response/2)
+        {:noreply, state}
+    end
+  end
+
+  defp process_response({:status, request_ref, status}, state) do
+    put_in(state.requests[request_ref].response[:status], status)
+  end
+
+  defp process_response({:headers, request_ref, headers}, state) do
+    put_in(state.requests[request_ref].response[:headers], headers)
+  end
+
+  defp process_response({:data, request_ref, data}, state) do
+    update_in(state.requests[request_ref].response[:data], fn data -> (data || "") <> data end)
+  end
+
+  # When the request is done, we use GenServer.reply/2 to reply to the caller that was
+  # blocked waiting on this request.
+  defp process_response({:done, request_ref}, state) do
+    {%{response: response, from: from}, state} = pop_in(state.conn[request_ref])
+    GenServer.reply(from, {:ok, response})
+    state
+  end
+
+  # A request can also error, but we're not handling the erroneous responses for
+  # brevity.
+end
+```


### PR DESCRIPTION
This will not show up in the docs until #65 is merged, otherwise we would have conflicts in the docs configuration in the `mix.exs` file.