### PR TITLE
Optional castore

### DIFF
--- a/lib/mint/core/transport/ssl.ex
+++ b/lib/mint/core/transport/ssl.ex
@@ -361,16 +361,26 @@ defmodule Mint.Core.Transport.SSL do
     default_ssl_opts(hostname)
     |> Keyword.merge(opts)
     |> Keyword.merge(@transport_opts)
-    |> add_cacerts()
-    |> add_partial_chain_fun()
-    |> add_verify_fun(hostname)
+    |> add_verify_opts(hostname)
+  end
+
+  defp add_verify_opts(opts, hostname) do
+    verify = Keyword.get(opts, :verify)
+
+    if verify == :verify_peer do
+      opts
+      |> add_cacerts()
+      |> add_partial_chain_fun()
+      |> add_verify_fun(hostname)
+    else
+      opts
+    end
   end
 
   defp add_verify_fun(opts, host_or_ip) do
-    verify = Keyword.get(opts, :verify)
     verify_fun_present? = Keyword.has_key?(opts, :verify_fun)
 
-    if verify == :verify_peer and not verify_fun_present? do
+    if not verify_fun_present? do
       host_or_ip = String.to_charlist(host_or_ip)
       reference_ids = [dns_id: host_or_ip, ip: host_or_ip]
       Keyword.put(opts, :verify_fun, {&verify_fun/3, reference_ids})

--- a/lib/mint/core/transport/ssl.ex
+++ b/lib/mint/core/transport/ssl.ex
@@ -431,6 +431,7 @@ defmodule Mint.Core.Transport.SSL do
     if Keyword.has_key?(opts, :cacertfile) || Keyword.has_key?(opts, :cacerts) do
       opts
     else
+      raise_on_missing_castore!()
       Keyword.put(opts, :cacertfile, CAStore.file_path())
     end
   end
@@ -514,4 +515,11 @@ defmodule Mint.Core.Transport.SSL do
 
   defp get_valid_suites([suit | rest], valid), do: get_valid_suites(rest, [suit | valid])
   defp get_valid_suites([], valid), do: valid
+
+  defp raise_on_missing_castore! do
+    Code.ensure_loaded?(CAStore) ||
+      raise "default CA trust store not available; " <>
+              "please add `:castore` to your project's dependencies or " <>
+              "specify the trust store using the `:cacertfile`/`:cacerts` option"
+  end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -46,7 +46,7 @@ defmodule Mint.MixProject do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
-      {:castore, "~> 0.1.0"},
+      {:castore, "~> 0.1.0", optional: true},
       {:ex_doc, "~> 0.19.3", only: :dev},
       {:hpack, ">= 0.0.0", hex: :hpack_erl, only: :test},
       {:stream_data, "~> 0.4.0", only: :test}


### PR DESCRIPTION
In order to allow users to use a custom CA trust store without carrying around an unnecessary dependency, the `castore` dependency should be optional.

Perhaps a note should be added to the README, suggesting people add `castore` while adding `mint` to their project unless they intend to use their own trust store.