### PR TITLE
Hide transport modules

### DIFF
--- a/lib/mint/core/transport.ex
+++ b/lib/mint/core/transport.ex
@@ -10,11 +10,11 @@ defmodule Mint.Core.Transport do
 
   @callback upgrade(
               Types.socket(),
-              old_transport :: module(),
+              original_scheme :: Types.scheme(),
               hostname :: String.t(),
               :inet.port_number(),
               opts :: keyword()
-            ) :: {:ok, {module(), Types.socket()}} | error()
+            ) :: {:ok, Types.socket()} | error()
 
   @callback negotiated_protocol(Types.socket()) ::
               {:ok, protocol :: binary()} | {:error, :protocol_not_negotiated}

--- a/lib/mint/core/transport/ssl.ex
+++ b/lib/mint/core/transport/ssl.ex
@@ -319,7 +319,7 @@ defmodule Mint.Core.Transport.SSL do
   end
 
   @impl true
-  def upgrade(socket, Mint.Core.Transport.TCP, hostname, _port, opts) do
+  def upgrade(socket, :http, hostname, _port, opts) do
     hostname = String.to_charlist(hostname)
     timeout = Keyword.get(opts, :timeout, @default_timeout)
 
@@ -327,19 +327,13 @@ defmodule Mint.Core.Transport.SSL do
     Mint.Core.Transport.TCP.setopts(socket, active: false)
 
     case :ssl.connect(socket, ssl_opts(hostname, opts), timeout) do
-      {:ok, socket} -> {:ok, {__MODULE__, socket}}
+      {:ok, socket} -> {:ok, socket}
       {:error, reason} -> {:error, reason}
     end
   end
 
-  def upgrade(_socket, Mint.Core.Transport.SSL, _hostname, _port, _opts) do
+  def upgrade(_socket, :https, _hostname, _port, _opts) do
     raise "nested SSL sessions are not supported"
-  end
-
-  def upgrade(state, transport, hostname, port, opts) do
-    socket = transport.socket(state)
-    transport = transport.actual_transport(state)
-    upgrade(socket, transport, hostname, port, opts)
   end
 
   @impl true

--- a/lib/mint/core/transport/tcp.ex
+++ b/lib/mint/core/transport/tcp.ex
@@ -25,8 +25,8 @@ defmodule Mint.Core.Transport.TCP do
   end
 
   @impl true
-  def upgrade(socket, transport, _hostname, _port, _opts) do
-    {:ok, {transport, socket}}
+  def upgrade(socket, _scheme, _hostname, _port, _opts) do
+    {:ok, socket}
   end
 
   @impl true

--- a/lib/mint/negotiate.ex
+++ b/lib/mint/negotiate.ex
@@ -4,7 +4,6 @@ defmodule Mint.Negotiate do
   import Mint.Core.Util
 
   alias Mint.{
-    Core.Transport,
     HTTP1,
     HTTP2
   }
@@ -23,100 +22,104 @@ defmodule Mint.Negotiate do
         HTTP2.connect(scheme, hostname, port, opts)
 
       [:http1, :http2] ->
-        transport = scheme_to_transport(scheme)
-        transport_connect(transport, hostname, port, opts)
+        transport_connect(scheme, hostname, port, opts)
     end
   end
 
-  def upgrade(old_transport, transport_state, scheme, hostname, port, opts) do
+  def upgrade(proxy_scheme, transport_state, scheme, hostname, port, opts) do
     {protocols, opts} = Keyword.pop(opts, :protocols, @default_protocols)
-    new_transport = scheme_to_transport(scheme)
 
     case Enum.sort(protocols) do
       [:http1] ->
-        HTTP1.upgrade(old_transport, transport_state, new_transport, hostname, port, opts)
+        HTTP1.upgrade(proxy_scheme, transport_state, scheme, hostname, port, opts)
 
       [:http2] ->
-        HTTP2.upgrade(old_transport, transport_state, new_transport, hostname, port, opts)
+        HTTP2.upgrade(proxy_scheme, transport_state, scheme, hostname, port, opts)
 
       [:http1, :http2] ->
-        transport_upgrade(old_transport, transport_state, new_transport, hostname, port, opts)
+        transport_upgrade(proxy_scheme, transport_state, scheme, hostname, port, opts)
     end
   end
 
   def initiate(transport, transport_state, hostname, port, opts),
     do: alpn_negotiate(transport, transport_state, hostname, port, opts)
 
-  defp transport_connect(Transport.TCP, hostname, port, opts) do
-    # TODO: http1 upgrade? Should be explicit since support is not clear
-    HTTP1.connect(Transport.TCP, hostname, port, opts)
+  defp transport_connect(:http, hostname, port, opts) do
+    # HTTP1 upgrade is not supported
+    HTTP1.connect(:http, hostname, port, opts)
   end
 
-  defp transport_connect(Transport.SSL, hostname, port, opts) do
-    connect_negotiate(Transport.SSL, hostname, port, opts)
+  defp transport_connect(:https, hostname, port, opts) do
+    connect_negotiate(:https, hostname, port, opts)
   end
 
-  defp connect_negotiate(transport, hostname, port, opts) do
+  defp connect_negotiate(scheme, hostname, port, opts) do
+    transport = scheme_to_transport(scheme)
+
     transport_opts =
       opts
       |> Keyword.get(:transport_opts, [])
       |> Keyword.merge(@transport_opts)
 
     case transport.connect(hostname, port, transport_opts) do
-      {:ok, transport_state} -> alpn_negotiate(transport, transport_state, hostname, port, opts)
+      {:ok, transport_state} -> alpn_negotiate(scheme, transport_state, hostname, port, opts)
       {:error, reason} -> {:error, reason}
     end
   end
 
   defp transport_upgrade(
-         old_transport,
+         proxy_scheme,
          transport_state,
-         Transport.TCP,
+         :http,
          hostname,
          port,
          opts
        ) do
-    # TODO: http1 upgrade? Should be explicit since support is not clear
-    HTTP1.upgrade(old_transport, transport_state, Transport.TCP, hostname, port, opts)
+    # HTTP1 upgrade is not supported
+    HTTP1.upgrade(proxy_scheme, transport_state, :http, hostname, port, opts)
   end
 
   defp transport_upgrade(
-         old_transport,
+         proxy_scheme,
          transport_state,
-         Transport.SSL,
+         :https,
          hostname,
          port,
          opts
        ) do
-    connect_upgrade(old_transport, transport_state, Transport.SSL, hostname, port, opts)
+    connect_upgrade(proxy_scheme, transport_state, :https, hostname, port, opts)
   end
 
-  defp connect_upgrade(old_transport, transport_state, new_transport, hostname, port, opts) do
+  defp connect_upgrade(proxy_scheme, transport_state, new_scheme, hostname, port, opts) do
+    transport = scheme_to_transport(new_scheme)
+
     transport_opts =
       opts
       |> Keyword.get(:transport_opts, [])
       |> Keyword.merge(@transport_opts)
 
-    case new_transport.upgrade(transport_state, old_transport, hostname, port, transport_opts) do
-      {:ok, {new_transport, transport_state}} ->
-        alpn_negotiate(new_transport, transport_state, hostname, port, opts)
+    case transport.upgrade(transport_state, proxy_scheme, hostname, port, transport_opts) do
+      {:ok, transport_state} ->
+        alpn_negotiate(new_scheme, transport_state, hostname, port, opts)
 
       {:error, reason} ->
         {:error, reason}
     end
   end
 
-  defp alpn_negotiate(transport, socket, hostname, port, opts) do
+  defp alpn_negotiate(scheme, socket, hostname, port, opts) do
+    transport = scheme_to_transport(scheme)
+
     case transport.negotiated_protocol(socket) do
       {:ok, "http/1.1"} ->
-        HTTP1.initiate(transport, socket, hostname, port, opts)
+        HTTP1.initiate(scheme, socket, hostname, port, opts)
 
       {:ok, "h2"} ->
-        HTTP2.initiate(transport, socket, hostname, port, opts)
+        HTTP2.initiate(scheme, socket, hostname, port, opts)
 
       {:error, :protocol_not_negotiated} ->
         # Assume HTTP1 if ALPN is not supported
-        HTTP1.initiate(transport, socket, hostname, port, opts)
+        HTTP1.initiate(scheme, socket, hostname, port, opts)
 
       {:ok, protocol} ->
         {:error, {:bad_alpn_protocol, protocol}}

--- a/lib/mint/tunnel_proxy.ex
+++ b/lib/mint/tunnel_proxy.ex
@@ -1,8 +1,6 @@
 defmodule Mint.TunnelProxy do
   @moduledoc false
 
-  import Mint.Core.Util
-
   alias Mint.{HTTP1, Negotiate}
 
   def connect(proxy, host) do
@@ -32,9 +30,10 @@ defmodule Mint.TunnelProxy do
 
   defp upgrade_connection(conn, proxy, {scheme, hostname, port, opts}) do
     {proxy_scheme, _proxy_hostname, _proxy_port, _proxy_opts} = proxy
-    transport = scheme_to_transport(proxy_scheme)
     socket = HTTP1.get_socket(conn)
-    Negotiate.upgrade(transport, socket, scheme, hostname, port, opts)
+
+    # Note that we may leak messages if the server sent data after the CONNECT response
+    Negotiate.upgrade(proxy_scheme, socket, scheme, hostname, port, opts)
   end
 
   defp receive_response(conn, ref) do

--- a/lib/mint/types.ex
+++ b/lib/mint/types.ex
@@ -44,7 +44,7 @@ defmodule Mint.Types do
   @typedoc """
   The scheme to use when connecting to an HTTP server.
   """
-  @type scheme :: :http | :https | module()
+  @type scheme :: :http | :https
 
   @typedoc false
   @type socket() :: term()


### PR DESCRIPTION
Transports are not public so they should not be leak through the API alongside schemas. Also fixes a issue in HTTP2 where the `:scheme` header can have confusing behavior.