### PR TITLE
Fix "Mint.HTTP.close/1" example

### DIFF
--- a/lib/mint/http.ex
+++ b/lib/mint/http.ex
@@ -305,8 +305,7 @@ defmodule Mint.HTTP do
 
   ## Examples
 
-      Mint.HTTP.close(conn)
-      #=> :ok
+      {:ok, conn} = Mint.HTTP.close(conn)
 
   """
   @impl true


### PR DESCRIPTION
To match

> Always returns `{:ok, conn}` where `conn` is the updated connection.