### PR TITLE
Add support for HTTP/2 server push

### DIFF
--- a/lib/mint/http.ex
+++ b/lib/mint/http.ex
@@ -493,6 +493,11 @@ defmodule Mint.HTTP do
       and will never be returned by an HTTP/1 connection. See `Mint.HTTP2.ping/2`
       for more information.
 
+    * `{:push_promise, request_ref, promised_request_ref, headers}` - returned when
+      the server sends a server push to the client. This response type is HTTP/2 specific
+      and will never be returned by an HTTP/1 connection. See `Mint.HTTP2` for more
+      information on server pushes.
+
   ## Examples
 
   Let's assume we have a function called `receive_next_and_stream/1` that takes

--- a/lib/mint/http2.ex
+++ b/lib/mint/http2.ex
@@ -1126,6 +1126,13 @@ defmodule Mint.HTTP2 do
       hbf: hbf
     ) = frame
 
+    # TODO: improve this by checking that the promised_stream_id is not in use or has been used
+    # before.
+    unless promised_stream_id > 0 and Integer.is_even(promised_stream_id) do
+      debug_data = "invalid promised stream ID: #{inspect(promised_stream_id)}"
+      send_connection_error(conn, :protocol_error, debug_data)
+    end
+
     stream = fetch_stream!(conn, stream_id)
     assert_stream_in_state(conn, stream, [:open, :half_closed_local])
 

--- a/lib/mint/http2.ex
+++ b/lib/mint/http2.ex
@@ -131,7 +131,7 @@ defmodule Mint.HTTP2 do
             server_max_concurrent_streams: non_neg_integer(),
             initial_window_size: pos_integer(),
             max_frame_size: pos_integer(),
-            headers_being_processed: {stream_id :: non_neg_integer(), iodata(), boolean()} | nil
+            headers_being_processed: {stream_id :: non_neg_integer(), iodata(), fun()} | nil
           }
 
   ## Public interface
@@ -847,8 +847,8 @@ defmodule Mint.HTTP2 do
 
   defp handle_frame(conn, settings() = frame, resps), do: handle_settings(conn, frame, resps)
 
-  # TODO: implement PUSH_PROMISE
-  defp handle_frame(_, push_promise(), _resps), do: raise("PUSH_PROMISE handling not implemented")
+  defp handle_frame(conn, push_promise() = frame, resps),
+    do: handle_push_promise(conn, frame, resps)
 
   defp handle_frame(conn, Frame.ping() = frame, resps), do: handle_ping(conn, frame, resps)
 
@@ -898,14 +898,16 @@ defmodule Mint.HTTP2 do
     if flag_set?(flags, :headers, :end_headers) do
       decode_hbf_and_add_responses(conn, responses, hbf, stream, end_stream?)
     else
-      conn = put_in(conn.headers_being_processed, {stream_id, hbf, end_stream?})
+      callback = &decode_hbf_and_add_responses(&1, &2, &3, &4, end_stream?)
+      conn = put_in(conn.headers_being_processed, {stream_id, hbf, callback})
       {conn, responses}
     end
   end
 
   defp decode_hbf_and_add_responses(conn, responses, hbf, stream, end_stream?) do
     case decode_hbf(conn, hbf) do
-      {:ok, status, headers, conn} ->
+      {:ok, [{":status", status} | headers], conn} ->
+        status = String.to_integer(status)
         responses = [{:headers, stream.ref, headers}, {:status, stream.ref, status} | responses]
 
         if end_stream? do
@@ -917,7 +919,7 @@ defmodule Mint.HTTP2 do
         end
 
       # http://httpwg.org/specs/rfc7540.html#rfc.section.8.1.2.6
-      {:error, :missing_status_header, conn} ->
+      {:ok, _headers, conn} ->
         conn = close_stream!(conn, stream.id, :protocol_error)
         reason = {:protocol_error, :missing_status_header}
         responses = [{:error, stream.ref, reason} | responses]
@@ -929,11 +931,7 @@ defmodule Mint.HTTP2 do
     case HPACK.decode(hbf, conn.decode_table) do
       {:ok, headers, decode_table} ->
         conn = put_in(conn.decode_table, decode_table)
-
-        case headers do
-          [{":status", status} | headers] -> {:ok, String.to_integer(status), headers, conn}
-          _other -> {:error, :missing_status_header, conn}
-        end
+        {:ok, headers, conn}
 
       {:error, reason} ->
         debug_data = "unable to decode headers: #{inspect(reason)}"
@@ -1042,6 +1040,60 @@ defmodule Mint.HTTP2 do
     put_in(conn.initial_window_size, new_iws)
   end
 
+  # PUSH_PROMISE
+
+  defp handle_push_promise(conn, push_promise() = frame, responses) do
+    push_promise(
+      stream_id: stream_id,
+      flags: flags,
+      promised_stream_id: promised_stream_id,
+      hbf: hbf
+    ) = frame
+
+    stream = fetch_stream!(conn, stream_id)
+    assert_stream_in_state(conn, stream, [:open, :half_closed_local])
+
+    if flag_set?(flags, :push_promise, :end_headers) do
+      decode_push_promise_headers_and_add_response(
+        conn,
+        responses,
+        hbf,
+        stream,
+        promised_stream_id
+      )
+    else
+      callback = &decode_push_promise_headers_and_add_response(&1, &2, &3, &4, promised_stream_id)
+      conn = put_in(conn.headers_being_processed, {stream_id, hbf, callback})
+      {conn, responses}
+    end
+  end
+
+  defp decode_push_promise_headers_and_add_response(
+         conn,
+         responses,
+         hbf,
+         stream,
+         promised_stream_id
+       ) do
+    {:ok, headers, conn} = decode_hbf(conn, hbf)
+
+    promised_stream = %{
+      id: promised_stream_id,
+      ref: make_ref(),
+      state: :idle,
+      window_size: conn.initial_window_size
+    }
+
+    conn = put_in(conn.streams[promised_stream.id], promised_stream)
+
+    responses = [
+      {:push_promise, stream.ref, %{promised_request_ref: promised_stream.ref, headers: headers}}
+      | responses
+    ]
+
+    {conn, responses}
+  end
+
   # PING
 
   defp handle_ping(conn, Frame.ping() = frame, responses) do
@@ -1137,13 +1189,14 @@ defmodule Mint.HTTP2 do
     continuation(stream_id: stream_id, flags: flags, hbf: hbf_chunk) = frame
     stream = fetch_stream!(conn, stream_id)
 
-    {^stream_id, hbf_acc, end_stream?} = conn.headers_being_processed
+    {^stream_id, hbf_acc, callback} = conn.headers_being_processed
 
     if flag_set?(flags, :continuation, :end_headers) do
       hbf = IO.iodata_to_binary([hbf_acc, hbf_chunk])
-      decode_hbf_and_add_responses(conn, responses, hbf, stream, end_stream?)
+      conn = put_in(conn.headers_being_processed, nil)
+      callback.(conn, responses, hbf, stream)
     else
-      conn = put_in(conn.headers_being_processed, {stream_id, [hbf_acc, hbf_chunk], end_stream?})
+      conn = put_in(conn.headers_being_processed, {stream_id, [hbf_acc, hbf_chunk], callback})
       {conn, responses}
     end
   end

--- a/lib/mint/http2.ex
+++ b/lib/mint/http2.ex
@@ -102,6 +102,7 @@ defmodule Mint.HTTP2 do
   }
 
   require Logger
+  require Integer
 
   @behaviour Mint.Core.Conn
 
@@ -1130,7 +1131,7 @@ defmodule Mint.HTTP2 do
     # before.
     unless promised_stream_id > 0 and Integer.is_even(promised_stream_id) do
       debug_data = "invalid promised stream ID: #{inspect(promised_stream_id)}"
-      send_connection_error(conn, :protocol_error, debug_data)
+      send_connection_error!(conn, :protocol_error, debug_data)
     end
 
     stream = fetch_stream!(conn, stream_id)

--- a/lib/mint/types.ex
+++ b/lib/mint/types.ex
@@ -23,6 +23,7 @@ defmodule Mint.Types do
           | {:data, request_ref(), body_chunk :: binary()}
           | {:done, request_ref()}
           | {:pong, request_ref()}
+          | {:push_promise, request_ref(), promised_request_ref :: request_ref(), headers()}
           | {:error, request_ref(), reason :: term()}
 
   @typedoc """

--- a/test/mint/http2/conn_test.exs
+++ b/test/mint/http2/conn_test.exs
@@ -307,8 +307,7 @@ defmodule Mint.HTTP2Test do
       {:ok, conn, ref} = HTTP2.request(context.conn, "GET", "/", [])
 
       assert {:ok, %HTTP2{} = conn, responses} = stream_until_responses_or_error(conn)
-      assert [{:push_promise, ^ref, metadata}] = responses
-      assert %{promised_request_ref: promised_ref, headers: headers} = metadata
+      assert [{:push_promise, ^ref, promised_ref, headers}] = responses
       assert is_reference(promised_ref)
       assert headers == [{":method", "GET"}, {"foo", "bar"}, {"baz", "bong"}]
 

--- a/test/mint/http2/integration_test.exs
+++ b/test/mint/http2/integration_test.exs
@@ -19,7 +19,7 @@ defmodule HTTP2.IntegrationTest do
   end
 
   describe "http2.golang.org" do
-    @moduletag connect: {"http2.golang.org", 443}
+    @describetag connect: {"http2.golang.org", 443}
 
     test "GET /reqinfo", %{conn: conn} do
       assert {:ok, %HTTP2{} = conn, req_id} = HTTP2.request(conn, "GET", "/reqinfo", [])
@@ -107,6 +107,19 @@ defmodule HTTP2.IntegrationTest do
       assert {:ok, %HTTP2{} = conn, [{:pong, ^ref}]} = receive_stream(conn)
       assert conn.buffer == ""
       assert HTTP2.open?(conn)
+    end
+
+    test "GET /serverpush", %{conn: conn} do
+      assert {:ok, %HTTP2{} = conn, req_id} = HTTP2.request(conn, "GET", "/serverpush", [])
+      assert {:ok, %HTTP2{} = conn, responses} = receive_stream(conn)
+
+      # TODO: improve this test by improving receive_stream/1.
+      assert [
+               {:push_promise, ^req_id, _promised_req_id1, _headers1},
+               {:push_promise, ^req_id, _promised_req_id2, _headers2},
+               {:push_promise, ^req_id, _promised_req_id3, _headers3},
+               {:push_promise, ^req_id, _promised_req_id4, _headers4} | _
+             ] = responses
     end
   end
 


### PR DESCRIPTION
This PR adds support for HTTP/2 [server push](https://en.wikipedia.org/wiki/HTTP/2_Server_Push). @josevalim and @ericmj, please take a look at the bottom of this text to help decide the API of the new request introduced in this PR.

Server push works like this:
* Client sends a normal request, say on stream ID 3.
* Server replies normally to the request on stream ID 3 plus it sends a `PUSH_PROMISE` frame on stream ID 3. This frame contains **request headers**, like `:method` and `:path`. Say that the server sends headers `[{":method", "GET"}, {":path", "/style.css"}]`. This is the server saying to the client: "I suspect you're going to do this request identified by these request headers (`GET /style.css` in our case), so I will later send you the response to this request directly without you actually making it.
* Server opens a new stream, say with stream ID 4, and sends a response to the `GET /style.css` request on stream ID 4. The new stream ID is called a "promised stream ID".

In the implementation, we will add a new type of response: a `:push_promise` response. This will need to contain the stream ID where the `PUSH_PROMISE` frame is sent (stream ID 3 in the example above, we will call this `request_ref`), the promised stream ID for the promised stream (stream ID 4 in the example above, we'll call this `promised_request_ref`), and the **request** headers associated with the promise. I need help with deciding the best format for this. Possible options:

1. `{:push_promise, request_ref, promised_request_ref, headers}`: this is the simplest option. The downside is that headers such as `:method`, `:path`, and `:authority` are treated specially in HTTP/2 and in our client as well: we return `{:status, _, status}` instead of showing the `:status` header for example.

1. `{:push_promise, request_ref, promised_request_ref, %{method: method, path: path, headers: headers}}`: a bit more cumbersome but treats special headers as metadata in this metadata map.

As soon as we decide, I'm going to add documentation. I'll also need to add some more checks for protocol errors. 