### PR TITLE
Improve error handling in Mint.HTTP2.stream/2

### DIFF
--- a/lib/mint/http2.ex
+++ b/lib/mint/http2.ex
@@ -522,7 +522,6 @@ defmodule Mint.HTTP2 do
     _ = transport.setopts(socket, active: :once)
     {:ok, conn, Enum.reverse(responses)}
   catch
-    :throw, {:mint, conn, error} -> {:error, conn, error, []}
     :throw, {:mint, conn, error, responses} -> {:error, conn, error, responses}
   end
 
@@ -877,8 +876,8 @@ defmodule Mint.HTTP2 do
         send_connection_error!(conn, :protocol_error, debug_data)
     end
   catch
-    :throw, {:mint, conn, error} ->
-      throw({:mint, conn, error, responses})
+    :throw, {:mint, conn, error} -> throw({:mint, conn, error, responses})
+    :throw, {:mint, conn, error, responses} -> throw({:mint, conn, error, responses})
   end
 
   defp assert_valid_frame(conn, frame) do


### PR DESCRIPTION
Closes #96.

Before this commit, we were not correctly handling all errors from `stream/2` and sometimes we would lose responses. We were sometimes throwing without responses and sometimes with responses from inside `handle_data/3` and its nested calls, and catching in `stream/2`. Now instead, we're catching inside `handle_data/3` so that we always re-throw  with all the responses we have at that moment.