### PR TITLE
Improve handling of frames coming in different states

### DIFF
--- a/test/mint/http2/conn_test.exs
+++ b/test/mint/http2/conn_test.exs
@@ -25,6 +25,18 @@ defmodule Mint.HTTP2Test do
     refute HTTP2.open?(conn)
   end
 
+  test "receiving a frame on a stream with a stream ID bigger than our biggest is an error",
+       %{server: server, conn: conn} do
+    stream_id = 3
+
+    TestServer.expect(server, fn state, headers(stream_id: ^stream_id) ->
+      TestServer.send_headers(state, _stream_id = 5, [{":status", "200"}], [:end_headers])
+    end)
+
+    {conn, _ref} = open_request(conn)
+    assert {:error, %HTTP2{} = conn, :protocol_error, []} = stream_until_responses_or_error(conn)
+  end
+
   describe "closed streams (RST_STREAM)" do
     test "server closes a stream with RST_STREAM", %{conn: conn, server: server} do
       TestServer.expect(server, fn state, headers(stream_id: stream_id) ->
@@ -59,17 +71,15 @@ defmodule Mint.HTTP2Test do
       assert {:ok, %HTTP2{} = conn, responses} = stream_until_responses_or_error(conn)
       assert responses == [{:error, ref, {:rst_stream, :cancel}}]
 
-      assert {:ok, %HTTP2{} = conn, []} = stream_next_message(conn)
+      assert {:error, %HTTP2{} = conn, reason, []} = stream_until_responses_or_error(conn)
+      assert {:bad_frame_on_closed_stream, headers(), _stream_id} = reason
     end
 
     test "closing a stream with cancel_request/2", %{conn: conn, server: server} do
       server
       |> TestServer.expect(fn state, headers(stream_id: stream_id) ->
-        {state, hbf} = TestServer.encode_headers(state, [{":status", "200"}])
-        flags = set_flag(:headers, :end_headers)
-
-        state =
-          TestServer.send_frame(state, headers(stream_id: stream_id, hbf: hbf, flags: flags))
+        headers = [{":status", "200"}]
+        state = TestServer.send_headers(state, stream_id, headers, [:end_headers])
 
         flags = set_flag(:data, :end_stream)
         TestServer.send_frame(state, data(stream_id: stream_id, data: "hello", flags: flags))
@@ -78,8 +88,7 @@ defmodule Mint.HTTP2Test do
         assert rst_stream(error_code: :cancel) = frame
         state
       end)
-      |> TestServer.expect(fn state, window_update(stream_id: 3) -> state end)
-      |> TestServer.expect(fn state, window_update(stream_id: 0) -> state end)
+      |> TestServer.allow_anything()
 
       {conn, ref} = open_request(conn)
       {:ok, conn} = HTTP2.cancel_request(conn, ref)
@@ -88,6 +97,100 @@ defmodule Mint.HTTP2Test do
       assert responses == []
 
       assert HTTP2.open?(conn)
+    end
+
+    test "if we cancel a stream and the server sends DATA after, we ignore the DATA",
+         %{server: server, conn: conn} do
+      server
+      |> TestServer.expect(fn state, headers(stream_id: stream_id) ->
+        TestServer.send_headers(state, stream_id, [{":status", "200"}], [:end_headers])
+      end)
+      |> TestServer.expect(fn state, rst_stream(stream_id: stream_id) ->
+        flags = set_flag(:data, :end_stream)
+        TestServer.send_frame(state, data(stream_id: stream_id, data: "hello", flags: flags))
+      end)
+      |> TestServer.allow_anything()
+
+      {conn, ref} = open_request(conn)
+      {:ok, conn} = HTTP2.cancel_request(conn, ref)
+
+      assert {:ok, %HTTP2{} = conn, responses} = stream_until_responses_or_error(conn)
+      assert [{:status, ^ref, 200}, {:headers, ^ref, []}] = responses
+
+      assert {:ok, %HTTP2{} = conn, responses} = stream_next_message(conn)
+      assert responses == []
+
+      assert HTTP2.open?(conn)
+    end
+
+    test "receiving a RST_STREAM on a closed stream is ignored", %{server: server, conn: conn} do
+      stream_id = 3
+
+      server
+      |> TestServer.expect(fn state, headers(stream_id: ^stream_id) ->
+        headers = [{":status", "200"}]
+        TestServer.send_headers(state, stream_id, headers, [:end_headers, :end_stream])
+      end)
+      |> TestServer.expect(fn state, rst_stream(stream_id: ^stream_id) ->
+        state
+        |> TestServer.send_frame(rst_stream(stream_id: stream_id, error_code: :no_error))
+        |> TestServer.send_frame(rst_stream(stream_id: stream_id, error_code: :no_error))
+      end)
+      |> TestServer.allow_anything()
+
+      {conn, ref} = open_request(conn)
+
+      assert {:ok, %HTTP2{} = conn, responses} = stream_until_responses_or_error(conn)
+      assert [{:status, ^ref, 200}, {:headers, ^ref, []}, {:done, ^ref}] = responses
+
+      assert {:ok, %HTTP2{} = conn, []} = stream_next_message(conn)
+      assert {:ok, %HTTP2{} = conn, []} = stream_next_message(conn)
+    end
+  end
+
+  describe "stream state transition nooks and crannies" do
+    test "if client receives DATA after receiving a END_STREAM flag, it errors",
+         %{server: server, conn: conn} do
+      stream_id = 3
+
+      server
+      |> TestServer.expect(fn state, headers(stream_id: ^stream_id) ->
+        headers = [{":status", "200"}]
+        state = TestServer.send_headers(state, stream_id, headers, [:end_headers, :end_stream])
+
+        flags = set_flags(:data, [:end_stream])
+        TestServer.send_frame(state, data(stream_id: stream_id, data: "hello", flags: flags))
+      end)
+      |> TestServer.allow_anything()
+
+      {conn, ref} = open_request(conn)
+
+      assert {:ok, %HTTP2{} = conn, responses} = stream_until_responses_or_error(conn)
+      assert [{:status, ^ref, 200}, {:headers, ^ref, []}, {:done, ^ref}] = responses
+
+      assert {:error, %HTTP2{} = conn, reason, []} = stream_until_responses_or_error(conn)
+      assert {:bad_frame_on_closed_stream, data(), ^stream_id} = reason
+    end
+
+    test "if client receives HEADERS after receiving a END_STREAM flag, it errors",
+         %{server: server, conn: conn} do
+      stream_id = 3
+
+      server
+      |> TestServer.expect(fn state, headers(stream_id: ^stream_id) ->
+        headers = [{":status", "200"}]
+        state = TestServer.send_headers(state, stream_id, headers, [:end_headers, :end_stream])
+        TestServer.send_headers(state, stream_id, headers, [:end_headers, :end_stream])
+      end)
+      |> TestServer.allow_anything()
+
+      {conn, ref} = open_request(conn)
+
+      assert {:ok, %HTTP2{} = conn, responses} = stream_until_responses_or_error(conn)
+      assert [{:status, ^ref, 200}, {:headers, ^ref, []}, {:done, ^ref}] = responses
+
+      assert {:error, %HTTP2{} = conn, reason, []} = stream_until_responses_or_error(conn)
+      assert {:bad_frame_on_closed_stream, headers(), ^stream_id} = reason
     end
   end
 


### PR DESCRIPTION
This is a little bit of a mess but it improves things. The idea is that there are really two "closed" states: the first one is when the server closes via `RST_STREAM` or when the server sends a frame with the `END_STREAM` flag set. In those cases, really we can throw away the stream because if the server then sends significant frames (`HEADERS`/`DATA`) on that stream we're supposed to error out. The trickier case is when we close the stream ourselves (see `cancel_request/2`): in those cases, the server is allowed (for a "short period" according to the spec) to still send `DATA`/`HEADERS` frames on the stream because it might have sent them before receiving our `RST_STREAM`. For those cases, for now I added a `:closed_by_us` stream state and when we receive frames on a `:closed_by_us` stream we just ignore them. This way we might never garbage collect `:closed_by_us` streams. My suggestion is that at some point we add timestamps to these and then whenever we do operations on the conn we check the timestamps and potentially garbage collect old `:closed_by_us` streams. Not really sure how else to tackle this problem.