### PR TITLE
Improve HTTP/2 test server

### DIFF
--- a/test/mint/http2/conn_test.exs
+++ b/test/mint/http2/conn_test.exs
@@ -381,11 +381,9 @@ defmodule Mint.HTTP2Test do
         {state, headers} = TestServer.decode_headers(state, hbf)
         assert [{":method", "GET"} | _] = headers
 
-        {state, hbf} = TestServer.encode_headers(state, [{":status", "200"}])
-
-        flags = set_flags(:headers, [:end_stream, :end_headers])
-        TestServer.send_frame(state, headers(stream_id: 3, hbf: hbf, flags: flags))
+        TestServer.send_headers(state, 3, [{":status", "200"}], [:end_stream, :end_headers])
       end)
+      |> TestServer.expect(fn state, rst_stream(stream_id: 3, error_code: :no_error) -> state end)
 
       # This is an empirical number of headers so that the minimum max frame size (~16kb) fits
       # between 2 and 3 times (so that we can test the behaviour above).
@@ -450,6 +448,7 @@ defmodule Mint.HTTP2Test do
           )
         ])
       end)
+      |> TestServer.expect(fn state, rst_stream(error_code: :no_error) -> state end)
 
       {conn, ref} = open_request(conn)
 

--- a/test/mint/http2/conn_test.exs
+++ b/test/mint/http2/conn_test.exs
@@ -454,6 +454,7 @@ defmodule Mint.HTTP2Test do
       end)
       |> TestServer.expect(fn state, rst_stream(error_code: :no_error) -> state end)
       |> TestServer.expect(fn state, window_update() -> state end)
+      |> TestServer.expect(fn state, window_update() -> state end)
 
       {conn, ref} = open_request(conn)
 

--- a/test/support/mint/http2/test_server.ex
+++ b/test/support/mint/http2/test_server.ex
@@ -215,7 +215,7 @@ defmodule Mint.HTTP2.TestServer do
     assert {:ok, unquote(connection_preface) <> rest} =
              :ssl.recv(socket, 0, @handshake_recv_timeout)
 
-    assert {:ok, settings(flags: no_flags, params: _), ""} = Frame.decode_next(rest)
+    assert {:ok, settings(flags: ^no_flags, params: _), ""} = Frame.decode_next(rest)
 
     assert :ok = :ssl.send(socket, encode(settings(params: [])))
 


### PR DESCRIPTION
Sometimes we would be okay with frames coming to the server after the test was done. This way we wait for the server to confirm that no data is left and no frames are left to handle.