### PR TITLE
Treat HTTP/1 header keys as case-insentive when adding defaults

### DIFF
--- a/lib/mint/http1/request.ex
+++ b/lib/mint/http1/request.ex
@@ -8,7 +8,7 @@ defmodule Mint.HTTP1.Request do
   @user_agent "mint/" <> Mix.Project.config()[:version]
 
   def encode(method, target, host, headers, body) do
-    headers = add_default_headers(headers, host, body)
+    headers = add_default_headers(lower_header_keys(headers), host, body)
 
     [
       encode_request_line(method, target),
@@ -23,19 +23,17 @@ defmodule Mint.HTTP1.Request do
     [method, ?\s, target, " HTTP/1.1\r\n"]
   end
 
+  defp lower_header_keys(headers) do
+    Enum.map(headers, fn {name, value} ->
+      {lower(name), value}
+    end)
+  end
+
   defp add_default_headers(headers, host, body) do
     headers
-    |> lower_header_keys()
     |> add_content_length(body)
     |> Util.put_new_header("user-agent", @user_agent)
     |> Util.put_new_header("host", host)
-  end
-
-  defp lower_header_keys(headers) do
-    Enum.reduce(headers, [], fn {name, value}, acc ->
-      [{lower(name), value} | acc]
-    end)
-    |> Enum.reverse()
   end
 
   defp add_content_length(headers, nil), do: headers

--- a/lib/mint/http1/request.ex
+++ b/lib/mint/http1/request.ex
@@ -25,9 +25,17 @@ defmodule Mint.HTTP1.Request do
 
   defp add_default_headers(headers, host, body) do
     headers
+    |> lower_header_keys()
     |> add_content_length(body)
     |> Util.put_new_header("user-agent", @user_agent)
     |> Util.put_new_header("host", host)
+  end
+
+  defp lower_header_keys(headers) do
+    Enum.reduce(headers, [], fn {name, value}, acc ->
+      [{lower(name), value} | acc]
+    end)
+    |> Enum.reverse()
   end
 
   defp add_content_length(headers, nil), do: headers

--- a/test/mint/http1/request_test.exs
+++ b/test/mint/http1/request_test.exs
@@ -51,6 +51,38 @@ defmodule Mint.HTTP1.RequestTest do
                """)
     end
 
+    test "with overridden user-agent" do
+      request =
+        Request.encode("GET", "/", "example.com", [{"user-agent", "myapp/1.0"}], "BODY")
+        |> IO.iodata_to_binary()
+
+      assert request ==
+               request_string("""
+               GET / HTTP/1.1
+               host: example.com
+               content-length: 4
+               user-agent: myapp/1.0
+
+               BODY\
+               """)
+    end
+
+    test "override with non-lowercase key" do
+      request =
+        Request.encode("GET", "/", "example.com", [{"User-Agent", "myapp/1.0"}], "BODY")
+        |> IO.iodata_to_binary()
+
+      assert request ==
+               request_string("""
+               GET / HTTP/1.1
+               host: example.com
+               content-length: 4
+               user-agent: myapp/1.0
+
+               BODY\
+               """)
+    end
+
     test "invalid request target" do
       assert catch_throw(Request.encode("GET", "/ /", "example.com", [], nil)) ==
                {:mint, :invalid_request_target}


### PR DESCRIPTION
RFC 2616 and 7230 state that header keys should be treated as case-insensitive. This change lowers headers keys before the defaults are added, so parsed in headers in a different case are not duplicated.

This change only applies to HTTP/1, but I believe something similar should be done for HTTP/2 (even though HTTP/2 headers should only be lower case). The code uses the `Mint.HTTP1.Parser.lower/1` function though. Maybe that should be moved to `Mint.Core.Util`?