### PR TITLE
correctly return timeout errors when connecting

### DIFF
--- a/lib/mint/core/transport/ssl.ex
+++ b/lib/mint/core/transport/ssl.ex
@@ -358,6 +358,7 @@ defmodule Mint.Core.Transport.SSL do
     default_ssl_opts(hostname)
     |> Keyword.merge(opts)
     |> Keyword.merge(@transport_opts)
+    |> Keyword.delete(:timeout)
     |> add_verify_opts(hostname)
   end
 

--- a/lib/mint/core/transport/tcp.ex
+++ b/lib/mint/core/transport/tcp.ex
@@ -19,7 +19,7 @@ defmodule Mint.Core.Transport.TCP do
     opts =
       opts
       |> Keyword.merge(@transport_opts)
-      |> Keyword.delete(:alpn_advertised_protocols)
+      |> Keyword.drop(~w(alpn_advertised_protocols timeout)a)
 
     :gen_tcp.connect(hostname, port, opts, timeout)
   end

--- a/test/mint/http1/integration_test.exs
+++ b/test/mint/http1/integration_test.exs
@@ -20,6 +20,14 @@ defmodule Mint.HTTP1.IntegrationTest do
     assert merge_body(responses, request) =~ "httpbin"
   end
 
+  test "timeout - httpbin.org" do
+    assert {:error, :timeout} =
+             HTTP1.connect(:http, "httpbin.org", 80, transport_opts: [timeout: 1])
+
+    assert {:error, :timeout} =
+             HTTP1.connect(:https, "httpbin.org", 443, transport_opts: [timeout: 1])
+  end
+
   test "ssl, path, long body - httpbin.org" do
     assert {:ok, conn} = HTTP1.connect(:https, "httpbin.org", 443)
 


### PR DESCRIPTION
The previous code would pass the `timeout` option to :gen_tcp or :gen_ssl,
neither of which support that as a keyword option.