### PR TITLE
Send a GOAWAY frame when closing an HTTP/2 connection

### DIFF
--- a/test/mint/http2/conn_test.exs
+++ b/test/mint/http2/conn_test.exs
@@ -20,7 +20,7 @@ defmodule Mint.HTTP2Test do
       refute HTTP2.open?(conn)
     end
 
-    test "socket error messageyeah i s are treated as errors", %{conn: conn} do
+    test "socket error messages are treated as errors", %{conn: conn} do
       message = {:ssl_error, conn.socket, :etimeout}
       assert {:error, %HTTP2{} = conn, :etimeout, []} = HTTP2.stream(conn, message)
       refute HTTP2.open?(conn)
@@ -170,6 +170,9 @@ defmodule Mint.HTTP2Test do
 
     test "client closes the connection with close/1", %{conn: conn} do
       assert {:ok, conn} = HTTP2.close(conn)
+
+      [goaway(error_code: :no_error)] = recv_next_frames(1)
+
       refute HTTP2.open?(conn)
     end
   end

--- a/test/support/mint/http2/test_server.ex
+++ b/test/support/mint/http2/test_server.ex
@@ -33,6 +33,8 @@ defmodule Mint.HTTP2.TestServer do
     assert_receive message, 100
     assert {:ok, %HTTP2{} = conn, []} = HTTP2.stream(conn, message)
 
+    :ok = :ssl.setopts(server_socket, active: true)
+
     server = %__MODULE__{
       socket: server_socket,
       encode_table: HPACK.new(4096),
@@ -55,8 +57,8 @@ defmodule Mint.HTTP2.TestServer do
     end
   end
 
-  defp recv_next_frames(server, n, frames, buffer) do
-    assert {:ok, data} = :ssl.recv(server.socket, 0, 100)
+  defp recv_next_frames(%{socket: server_socket} = server, n, frames, buffer) do
+    assert_receive {:ssl, ^server_socket, data}, 100
     decode_next_frames(server, n, frames, buffer <> data)
   end
 


### PR DESCRIPTION
Closes #108.

I'm not 100% sure we want to do this since performance-wise it's not optimal as we can just close the socket and not care, but the protocol says we should 🤷‍♀️ 

One thing to note, I changed the test server so that instead of having a passive socket where we have to do `recv` on it, we have an active socket and use `assert_receive`. I did this because otherwise the test for `close/1` couldn't verify the GOAWAY frame was received by the server, since `close/1` would close the socket and we wouldn't be able to `recv` anything. On the bright side, seems like we came up with a good abstraction and set of helpers since the change to the test server was really minimal :)