### PR TITLE
Refactor HTTP/2 tests with assert_recv_frames

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -5,6 +5,7 @@
     # TODO: remove this once we depend on newer stream_data, which provide this if you
     # import their configuration.
     all: :*,
-    assert_round_trip: 1
+    assert_round_trip: 1,
+    assert_recv_frames: 1
   ]
 ]


### PR DESCRIPTION
This macro hides the call to `recv_next_frames/1`. The benefit of doing this is that we can infer the number of frames we expect by the length of the list of frames that we pass to the `assert_recv_frames/1` macro. Plus, when we know that `assert record() = ...` works correctly, we can replace it in only one place (inside the new macro).

@ericmj I am not sure this is a good idea and I'm not sure that the magic introduced by this is worth introducing. The tests might look better but maybe it's hard to know what's going on. Would love the opinion of a fresh set of eyes :)