### PR TITLE
Strip whitespace when parsing content-length header

### DIFF
--- a/lib/mint/http1/parse.ex
+++ b/lib/mint/http1/parse.ex
@@ -48,7 +48,7 @@ defmodule Mint.HTTP1.Parse do
   def ignore_until_crlf(<<_char, rest::binary>>), do: ignore_until_crlf(rest)
 
   def content_length_header(string) do
-    case Integer.parse(string) do
+    case Integer.parse(String.trim(string)) do
       {length, ""} when length >= 0 ->
         length
 

--- a/lib/mint/http1/parse.ex
+++ b/lib/mint/http1/parse.ex
@@ -48,7 +48,7 @@ defmodule Mint.HTTP1.Parse do
   def ignore_until_crlf(<<_char, rest::binary>>), do: ignore_until_crlf(rest)
 
   def content_length_header(string) do
-    case Integer.parse(String.trim(string)) do
+    case Integer.parse(String.trim_trailing(string)) do
       {length, ""} when length >= 0 ->
         length
 

--- a/test/mint/http1/parse_test.exs
+++ b/test/mint/http1/parse_test.exs
@@ -14,10 +14,21 @@ defmodule Mint.HTTP1.ParseTest do
 
   test "connection_header/1" do
     assert connection_header("close") == ["close"]
+    assert connection_header("close  ") == ["close"]
     assert connection_header("Keep-Alive") == ["keep-alive"]
     assert connection_header("keep-alive, Upgrade") == ["keep-alive", "upgrade"]
+    assert connection_header("keep-alive,  Upgrade  ") == ["keep-alive", "upgrade"]
 
     assert catch_throw(connection_header("\n")) == {:mint, :invalid_token_list}
+  end
+
+  test "transfer_encoding_header/1" do
+    assert transfer_encoding_header("deflate") == ["deflate"]
+    assert transfer_encoding_header("deflate  ") == ["deflate"]
+    assert transfer_encoding_header("gzip, Chunked") == ["gzip", "chunked"]
+    assert transfer_encoding_header("gzip,   Chunked  ") == ["gzip", "chunked"]
+
+    assert catch_throw(transfer_encoding_header("\n")) == {:mint, :invalid_token_list}
   end
 
   test "token_list/1" do

--- a/test/mint/http1/parse_test.exs
+++ b/test/mint/http1/parse_test.exs
@@ -6,7 +6,7 @@ defmodule Mint.HTTP1.ParseTest do
   test "content_length_header/1" do
     assert content_length_header("0") == 0
     assert content_length_header("100") == 100
-    assert content_length_header("  200  ") == 200
+    assert content_length_header("200  ") == 200
 
     assert catch_throw(content_length_header("foo")) == {:mint, :invalid_content_length_header}
     assert catch_throw(content_length_header("-10")) == {:mint, :invalid_content_length_header}

--- a/test/mint/http1/parse_test.exs
+++ b/test/mint/http1/parse_test.exs
@@ -6,6 +6,7 @@ defmodule Mint.HTTP1.ParseTest do
   test "content_length_header/1" do
     assert content_length_header("0") == 0
     assert content_length_header("100") == 100
+    assert content_length_header("  200  ") == 200
 
     assert catch_throw(content_length_header("foo")) == {:mint, :invalid_content_length_header}
     assert catch_throw(content_length_header("-10")) == {:mint, :invalid_content_length_header}


### PR DESCRIPTION
Per RFC 7230:

```
   Each header field consists of a case-insensitive field name followed
   by a colon (":"), optional leading whitespace, the field value, and
   optional trailing whitespace.
```