### PR TITLE
Improve a couple of HTTP/1 header-related errors

### DIFF
--- a/lib/mint/http1.ex
+++ b/lib/mint/http1.ex
@@ -649,9 +649,8 @@ defmodule Mint.HTTP1 do
     "invalid header"
   end
 
-  # TODO: maybe add the target here.
-  def format_error(:invalid_request_target) do
-    "invalid request target"
+  def format_error({:invalid_request_target, target}) do
+    "invalid request target: #{inspect(target)}"
   end
 
   def format_error({:invalid_header_name, name}) do
@@ -682,9 +681,8 @@ defmodule Mint.HTTP1 do
     "the response contained both a Transfer-Encoding header as well as a Content-Length header"
   end
 
-  # TODO: maybe include the header value here.
-  def format_error(:invalid_content_length_header) do
-    "invalid Content-Length header"
+  def format_error({:invalid_content_length_header, value}) do
+    "invalid Content-Length header: #{inspect(value)}"
   end
 
   # TODO: :invalid_token_list

--- a/lib/mint/http1/parse.ex
+++ b/lib/mint/http1/parse.ex
@@ -53,7 +53,7 @@ defmodule Mint.HTTP1.Parse do
         length
 
       _other ->
-        throw({:mint, :invalid_content_length_header})
+        throw({:mint, {:invalid_content_length_header, string}})
     end
   end
 

--- a/lib/mint/http1/request.ex
+++ b/lib/mint/http1/request.ex
@@ -62,7 +62,7 @@ defmodule Mint.HTTP1.Request do
     _ =
       for <<char <- target>> do
         unless URI.char_unescaped?(char) do
-          throw({:mint, :invalid_request_target})
+          throw({:mint, {:invalid_request_target, target}})
         end
       end
 

--- a/test/mint/http1/parse_test.exs
+++ b/test/mint/http1/parse_test.exs
@@ -7,8 +7,11 @@ defmodule Mint.HTTP1.ParseTest do
     assert content_length_header("0") == 0
     assert content_length_header("100") == 100
 
-    assert catch_throw(content_length_header("foo")) == {:mint, :invalid_content_length_header}
-    assert catch_throw(content_length_header("-10")) == {:mint, :invalid_content_length_header}
+    assert catch_throw(content_length_header("foo")) ==
+             {:mint, {:invalid_content_length_header, "foo"}}
+
+    assert catch_throw(content_length_header("-10")) ==
+             {:mint, {:invalid_content_length_header, "-10"}}
   end
 
   test "connection_header/1" do

--- a/test/mint/http1/request_test.exs
+++ b/test/mint/http1/request_test.exs
@@ -85,7 +85,7 @@ defmodule Mint.HTTP1.RequestTest do
 
     test "invalid request target" do
       assert catch_throw(Request.encode("GET", "/ /", "example.com", [], nil)) ==
-               {:mint, :invalid_request_target}
+               {:mint, {:invalid_request_target, "/ /"}}
     end
 
     test "invalid header name" do


### PR DESCRIPTION
I added more information to the `:invalid_request_target` and `:invalid_content_length_header` errors.