### PR TITLE
Fix target validation when building HTTP/1 requests

### DIFF
--- a/test/mint/http1/request_test.exs
+++ b/test/mint/http1/request_test.exs
@@ -84,9 +84,7 @@ defmodule Mint.HTTP1.RequestTest do
     end
 
     test "validates request target" do
-      invalid_targets = ["/ /", "/%foo", "/foo%x"]
-
-      for invalid_target <- invalid_targets do
+      for invalid_target <- ["/ /", "/%foo", "/foo%x"] do
         assert catch_throw(Request.encode("GET", invalid_target, "example.com", [], nil)) ==
                  {:mint, {:invalid_request_target, invalid_target}}
       end

--- a/test/mint/http1/request_test.exs
+++ b/test/mint/http1/request_test.exs
@@ -83,9 +83,18 @@ defmodule Mint.HTTP1.RequestTest do
                """)
     end
 
-    test "invalid request target" do
-      assert catch_throw(Request.encode("GET", "/ /", "example.com", [], nil)) ==
-               {:mint, {:invalid_request_target, "/ /"}}
+    test "validates request target" do
+      invalid_targets = ["/ /", "/%foo", "/foo%x"]
+
+      for invalid_target <- invalid_targets do
+        assert catch_throw(Request.encode("GET", invalid_target, "example.com", [], nil)) ==
+                 {:mint, {:invalid_request_target, invalid_target}}
+      end
+
+      request =
+        Request.encode("GET", "/foo%20bar", "example.com", [], nil) |> IO.iodata_to_binary()
+
+      assert String.starts_with?(request, request_string("GET /foo%20bar HTTP/1.1"))
     end
 
     test "invalid header name" do


### PR DESCRIPTION
Closes #110.

Before this change, we only checked that a HTTP/1 request target only contained chars that are allowed unescaped. This means that the target validation failed when escaped characters `%xx` were in the validated URL. With this change, we allow chars that are allowed unescaped plus `%xx` escaped chars.