### PR TITLE
Simplify HTTP/1 header parsing and test it through property-based testing

### DIFF
--- a/lib/mint/http1.ex
+++ b/lib/mint/http1.ex
@@ -522,16 +522,18 @@ defmodule Mint.HTTP1 do
     do: [{:data, request_ref, new_data} | responses]
 
   defp store_header(%{content_length: nil} = request, "content-length", value) do
-    {:ok, %{request | content_length: Parse.content_length_header(value)}}
+    with {:ok, content_length} <- Parse.content_length_header(value),
+         do: {:ok, %{request | content_length: content_length}}
   end
 
   defp store_header(%{connection: connection} = request, "connection", value) do
-    {:ok, %{request | connection: connection ++ Parse.connection_header(value)}}
+    with {:ok, connection_header} <- Parse.connection_header(value),
+         do: {:ok, %{request | connection: connection ++ connection_header}}
   end
 
   defp store_header(%{transfer_encoding: transfer_encoding} = request, "transfer-encoding", value) do
-    {:ok,
-     %{request | transfer_encoding: transfer_encoding ++ Parse.transfer_encoding_header(value)}}
+    with {:ok, transfer_encoding_header} <- Parse.transfer_encoding_header(value),
+         do: {:ok, %{request | transfer_encoding: transfer_encoding ++ transfer_encoding_header}}
   end
 
   defp store_header(_request, "content-length", _value) do

--- a/test/mint/http1/parse_test.exs
+++ b/test/mint/http1/parse_test.exs
@@ -1,58 +1,66 @@
 defmodule Mint.HTTP1.ParseTest do
   use ExUnit.Case, async: true
+  use ExUnitProperties
 
   import Mint.HTTP1.Parse
 
   test "content_length_header/1" do
-    assert content_length_header("0") == 0
-    assert content_length_header("100") == 100
-    assert content_length_header("200  ") == 200
+    assert content_length_header("0") == {:ok, 0}
+    assert content_length_header("100") == {:ok, 100}
+    assert content_length_header("200  ") == {:ok, 200}
 
-    assert catch_throw(content_length_header("foo")) ==
-             {:mint, {:invalid_content_length_header, "foo"}}
+    assert content_length_header("foo") ==
+             {:error, {:invalid_content_length_header, "foo"}}
 
-    assert catch_throw(content_length_header("-10")) ==
-             {:mint, {:invalid_content_length_header, "-10"}}
+    assert content_length_header("-10") ==
+             {:error, {:invalid_content_length_header, "-10"}}
   end
 
   test "connection_header/1" do
-    assert connection_header("close") == ["close"]
-    assert connection_header("close  ") == ["close"]
-    assert connection_header("Keep-Alive") == ["keep-alive"]
-    assert connection_header("keep-alive, Upgrade") == ["keep-alive", "upgrade"]
-    assert connection_header("keep-alive,  Upgrade  ") == ["keep-alive", "upgrade"]
+    assert connection_header("close") == {:ok, ["close"]}
+    assert connection_header("close  ") == {:ok, ["close"]}
+    assert connection_header("Keep-Alive") == {:ok, ["keep-alive"]}
+    assert connection_header("keep-alive, Upgrade") == {:ok, ["keep-alive", "upgrade"]}
+    assert connection_header("keep-alive,  Upgrade  ") == {:ok, ["keep-alive", "upgrade"]}
 
-    assert catch_throw(connection_header("\n")) == {:mint, :invalid_token_list}
+    assert connection_header("\n") == {:error, :invalid_token_list}
+    assert connection_header("") == {:error, :empty_token_list}
   end
 
   test "transfer_encoding_header/1" do
-    assert transfer_encoding_header("deflate") == ["deflate"]
-    assert transfer_encoding_header("deflate  ") == ["deflate"]
-    assert transfer_encoding_header("gzip, Chunked") == ["gzip", "chunked"]
-    assert transfer_encoding_header("gzip,   Chunked  ") == ["gzip", "chunked"]
+    assert transfer_encoding_header("deflate") == {:ok, ["deflate"]}
+    assert transfer_encoding_header("deflate  ") == {:ok, ["deflate"]}
+    assert transfer_encoding_header("gzip, Chunked") == {:ok, ["gzip", "chunked"]}
+    assert transfer_encoding_header("gzip,   Chunked  ") == {:ok, ["gzip", "chunked"]}
 
-    assert catch_throw(transfer_encoding_header("\n")) == {:mint, :invalid_token_list}
+    assert transfer_encoding_header("\n") == {:error, :invalid_token_list}
+    assert transfer_encoding_header("") == {:error, :empty_token_list}
   end
 
-  test "token_list/1" do
-    assert token_list("") == []
-    assert token_list("foo") == ["foo"]
-    assert token_list("foo, bar") == ["foo", "bar"]
-    assert token_list("foo,bAr") == ["foo", "bAr"]
-    assert token_list(",, , ,   ,") == []
-    assert token_list("   ,  ,,,  foo  , ,  ") == ["foo"]
+  describe "token_list_downcase/1" do
+    property "returns an empty list if there's no token" do
+      check all string <- string([?\s, ?\t, ?,]) do
+        assert token_list_downcase(string) == []
+      end
+    end
 
-    assert catch_throw(token_list("\n")) == {:mint, :invalid_token_list}
-  end
+    property "parses lists of tokens and downcases them" do
+      check all tokens <- list_of(string(:alphanumeric, min_length: 1)),
+                whitespace <- string([?\s, ?\t]),
+                string = Enum.join(tokens, whitespace <> "," <> whitespace) do
+        assert token_list_downcase(string) == Enum.map(tokens, &String.downcase/1)
+      end
+    end
 
-  test "token_list_downcase/1" do
-    assert token_list_downcase("") == []
-    assert token_list_downcase("foo") == ["foo"]
-    assert token_list_downcase("foo, bar") == ["foo", "bar"]
-    assert token_list_downcase("FOO,bAr") == ["foo", "bar"]
-    assert token_list_downcase(",, , ,   ,") == []
-    assert token_list_downcase("   ,  ,,,  foo  , ,  ") == ["foo"]
+    test "parses practical examples" do
+      assert token_list_downcase("foo") == ["foo"]
+      assert token_list_downcase("foo, bar") == ["foo", "bar"]
+      assert token_list_downcase("FOO,bAr") == ["foo", "bar"]
+      assert token_list_downcase("   ,  ,,,  foo  , ,  ") == ["foo"]
+    end
 
-    assert catch_throw(token_list_downcase("\n")) == {:mint, :invalid_token_list}
+    test "throws {:mint, :invalid_token_list} for invalid tokens" do
+      assert catch_throw(token_list_downcase("\n")) == {:mint, :invalid_token_list}
+    end
   end
 end


### PR DESCRIPTION
Closes #126.

I also removed cross-module throw/catch instances coming from the `Mint.HTTP1.Parse` module, similar to what was done in #136.