### PR TITLE
Simplify and improve errors in Mint.HTTP1.Parse

### DIFF
--- a/lib/mint/http1.ex
+++ b/lib/mint/http1.ex
@@ -575,8 +575,7 @@ defmodule Mint.HTTP1 do
     %{conn | state: :closed}
   end
 
-  # TODO: We should probably error if both transfer-encoding and content-length
-  # is set. RFC7230 3.3.3:
+  # RFC7230 3.3.3:
   # > If a message is received with both a Transfer-Encoding and a
   # > Content-Length header field, the Transfer-Encoding overrides the
   # > Content-Length.  Such a message might indicate an attempt to
@@ -687,6 +686,11 @@ defmodule Mint.HTTP1 do
     "invalid Content-Length header: #{inspect(value)}"
   end
 
-  # TODO: :invalid_token_list
-  # TODO: :empty_token_list
+  def format_error(:empty_token_list) do
+    "header should contain a list of values, but it doesn't"
+  end
+
+  def format_error({:invalid_token_list, string}) do
+    "header contains invalid tokens: #{inspect(string)}"
+  end
 end

--- a/lib/mint/http1/parse.ex
+++ b/lib/mint/http1/parse.ex
@@ -38,18 +38,17 @@ defmodule Mint.HTTP1.Parse do
   end
 
   defp split_into_downcase_tokens(string) do
-    token_list_downcase(string)
-  catch
-    {:mint, error} -> {:error, error}
-  else
-    [] -> {:error, :empty_token_list}
-    list -> {:ok, list}
+    case token_list_downcase(string) do
+      {:ok, []} -> {:error, :empty_token_list}
+      {:ok, list} -> {:ok, list}
+      :error -> {:error, {:invalid_token_list, string}}
+    end
   end
 
   # Made public for testing.
   def token_list_downcase(string), do: token_list_downcase(string, [])
 
-  defp token_list_downcase(<<>>, acc), do: :lists.reverse(acc)
+  defp token_list_downcase(<<>>, acc), do: {:ok, :lists.reverse(acc)}
 
   # Skip all whitespace and commas.
   defp token_list_downcase(<<char, rest::binary>>, acc)
@@ -63,7 +62,7 @@ defmodule Mint.HTTP1.Parse do
 
   defp token_downcase(rest, token_acc, acc), do: token_list_sep_downcase(rest, [token_acc | acc])
 
-  defp token_list_sep_downcase(<<>>, acc), do: :lists.reverse(acc)
+  defp token_list_sep_downcase(<<>>, acc), do: {:ok, :lists.reverse(acc)}
 
   defp token_list_sep_downcase(<<char, rest::binary>>, acc) when is_whitespace(char),
     do: token_list_sep_downcase(rest, acc)
@@ -71,5 +70,5 @@ defmodule Mint.HTTP1.Parse do
   defp token_list_sep_downcase(<<char, rest::binary>>, acc) when is_comma(char),
     do: token_list_downcase(rest, acc)
 
-  defp token_list_sep_downcase(_rest, _acc), do: throw({:mint, :invalid_token_list})
+  defp token_list_sep_downcase(_rest, _acc), do: :error
 end


### PR DESCRIPTION
Closes #138.

I removed all throw/catches in `Mint.HTTP1.Parse` as they were unnecessary. I also improved the `:invalid_token_list` error when parsing HTTP/1 header values so that it shows the offending string. I finally added formatting to the `:invalid_token_list` and `:empty_token_list` errors in `Mint.HTTP1`.