### PR TITLE
Clean up and improve HTTP error reasons and document them

### DIFF
--- a/lib/mint/http1.ex
+++ b/lib/mint/http1.ex
@@ -36,7 +36,6 @@ defmodule Mint.HTTP1 do
 
       * `:invalid_status_line` - when the HTTP/1 status line is invalid.
 
-
       * `{:invalid_request_target, target}` - when the request target is invalid.
 
       * `:invalid_header` - when headers can't be parsed correctly.

--- a/lib/mint/http1.ex
+++ b/lib/mint/http1.ex
@@ -24,6 +24,52 @@ defmodule Mint.HTTP1 do
 
   @opaque t() :: %__MODULE__{}
 
+  @typedoc """
+  An HTTP/1-specific error reason.
+
+  The values can be:
+
+      * `:request_body_is_streaming` - when you call `request/5` to send a new
+        request but another request is already streaming.
+
+      * `{:unexpected_data, data}` - when unexpected data is received from the server.
+
+      * `:invalid_status_line` - when the HTTP/1 status line is invalid.
+
+
+      * `{:invalid_request_target, target}` - when the request target is invalid.
+
+      * `:invalid_header` - when headers can't be parsed correctly.
+
+      * `{:invalid_header_name, name}` - when a header name is invalid.
+
+      * `{:invalid_header_value, name, value}` - when a header value is invalid. `name`
+        is the name of the header and `value` is the invalid value.
+
+      * `:invalid_chunk_size` - when the chunk size is invalid.
+
+      * `:missing_crlf_after_chunk` - when the CRLF after a chunk is missing.
+
+      * `:invalid_trailer_header` - when trailer headers can't be parsed.
+
+      * `:more_than_one_content_length_header` - when more than one `content-length`
+        headers are in the response.
+
+      * `:transfer_encoding_and_content_length` - when both the `content-length` as well
+        as the `transfer-encoding` headers are in the response.
+
+      * `{:invalid_content_length_header, value}` - when the value of the `content-length`
+        header is invalid, that is, is not an non-negative integer.
+
+      * `:empty_token_list` - when a header that is supposed to contain a list of tokens
+        (such as the `connection` header) doesn't contain any.
+
+      * `{:invalid_token_list, string}` - when a header that is supposed to contain a list
+        of tokens (such as the `connection` header) contains a malformed list of tokens.
+
+  """
+  @type error_reason() :: term()
+
   defstruct [
     :host,
     :request,
@@ -644,10 +690,6 @@ defmodule Mint.HTTP1 do
 
   @doc false
   def format_error(reason)
-
-  def format_error(:closed) do
-    "the connection was closed"
-  end
 
   def format_error(:request_body_is_streaming) do
     "a request body is currently streaming, so no new requests can be issued"

--- a/lib/mint/http_error.ex
+++ b/lib/mint/http_error.ex
@@ -1,5 +1,47 @@
 defmodule Mint.HTTPError do
-  @type t() :: %__MODULE__{reason: term()}
+  @moduledoc """
+  An HTTP error.
+
+  This exception struct is used to represent HTTP errors of all sorts and for
+  both HTTP/1 and HTTP/2.
+
+
+  A `Mint.HTTPError` struct is an exception, so it can be raised as any
+  other exception.
+
+  ## Struct
+
+  The `Mint.HTTPError` struct is opaque, that is, not all of its fields are public.
+  The list of public fields is:
+
+    * `:reason` - the error reason. Can be one of:
+
+      * a term of type `t:Mint.HTTP1.error_reason/0`. See its documentation for
+        more information.
+
+      * a term of type `t:Mint.HTTP2.error_reason/0`. See its documentation for
+        more information.
+
+      * `:tunnel_timeout` - when you're using a tunnel proxy and the tunnel times out.
+
+      * `{:unexpected_status, status}` - when you're using a tunnel proxy and
+        the proxy returns an unexpected status `status`.
+
+      * `{:unexpected_trailing_responses, responses}` - when you're using a tunnel proxy
+        and the proxy returns unexpected responses (`responses`).
+
+  ## Message representation
+
+  If you want to convert an error reason to a human-friendly message (for example
+  for using in logs), you can use `Exception.message/1`:
+
+      iex> {:error, %Mint.HTTPError{} = error} = Mint.HTTP.connect(:http, "badresponse.com", 80)
+      iex> Exception.message(error)
+      "the response contains two or more Content-Length headers"
+
+  """
+
+  @opaque t() :: %__MODULE__{reason: term(), module: module()}
 
   defexception [:reason, :module]
 

--- a/lib/mint/tunnel_proxy.ex
+++ b/lib/mint/tunnel_proxy.ex
@@ -55,7 +55,7 @@ defmodule Mint.TunnelProxy do
         stream(conn, ref, timeout_deadline, msg)
     after
       timeout ->
-        {:error, conn, %HTTPError{reason: :tunnel_timeout}}
+        {:error, conn, wrap_error(:tunnel_timeout)}
     end
   end
 

--- a/test/mint/http2/frame_test.exs
+++ b/test/mint/http2/frame_test.exs
@@ -51,9 +51,10 @@ defmodule Mint.HTTP2.FrameTest do
     test "with bad padding" do
       # "payload" is 4 bytes, the pad length is >= 5 bytes
       payload = <<5::8, "data">>
+      debug_data = "the padding length of a :data frame is bigger than the payload length"
 
       assert Frame.decode_next(encode_raw(0x00, 0x08, 3, payload)) ==
-               {:error, {:protocol_error, {:pad_length_bigger_than_payload_length, :data}}}
+               {:error, {:protocol_error, debug_data}}
     end
   end
 
@@ -248,7 +249,7 @@ defmodule Mint.HTTP2.FrameTest do
 
     test "invalid window size increment" do
       assert Frame.decode_next(encode_raw(0x08, 0x00, 0, <<0::1, 0::31>>)) ==
-               {:error, {:protocol_error, :bad_window_size_increment}}
+               {:error, {:protocol_error, "bad WINDOW_SIZE increment"}}
     end
 
     test "with bad length" do


### PR DESCRIPTION
@ericmj we need to discuss `TunnelProxy` errors. We can

1. make a `Mint.ProxyError`. It can use `Mint.HTTPError` to format the inner error but add some proxy-specific stuff.

2. wrap all `Mint.HTTPError` errors in `TunnelProxy` by changing the formatter module to `TunnelProxy` and the reason to `{:proxy, original_reason}`. Then we tell users that all reasons documented for `Mint.HTTPError` (for HTTP/1) can also come wrapped inside a `{:proxy, _}` tuple. This avoids introducing a third error type users need to care about, but it's a bit messier with the recursive `{:proxy, reason}` error reason.

Wdyt? Any other ideas?