### PR TITLE
Don't break opaque type boundaries in Mint.UnsafeProxy

### DIFF
--- a/lib/mint/unsafe_proxy.ex
+++ b/lib/mint/unsafe_proxy.ex
@@ -28,7 +28,7 @@ defmodule Mint.UnsafeProxy do
         scheme: scheme,
         hostname: hostname,
         port: port,
-        module: state.__struct__,
+        module: Mint.HTTP1,
         state: state
       }
 


### PR DESCRIPTION
@ericmj I'm not sure that the module here is always `Mint.HTTP1` but we **are** calling `Mint.HTTP1.connect/4` directly. I'm doing this change because it fixes a Dialyzer warning about breaking the opacity of the `Mint.HTTP1` struct. Wdyt?