### PR TITLE
Fix a bug in the HTTP/2 handshake

### DIFF
--- a/lib/mint/http2.ex
+++ b/lib/mint/http2.ex
@@ -930,9 +930,19 @@ defmodule Mint.HTTP2 do
 
   defp receive_server_settings(transport, socket) do
     case recv_next_frame(transport, socket, _buffer = "") do
-      {:ok, settings(), _buffer, _socket} = result -> result
-      {:ok, _frame, _buffer, _socket} -> {:error, wrap_error(:protocol_error)}
-      {:error, _reason} = error -> error
+      {:ok, settings(), _buffer, _socket} = result ->
+        result
+
+      {:ok, goaway(error_code: error_code, debug_data: debug_data), _buffer, _socket} ->
+        error = wrap_error({:server_closed_connection, error_code, debug_data})
+        {:error, error}
+
+      {:ok, frame, _buffer, _socket} ->
+        debug_data = "received invalid frame #{elem(frame, 0)} during handshake"
+        {:error, wrap_error({:protocol_error, debug_data})}
+
+      {:error, error} ->
+        {:error, error}
     end
   end
 


### PR DESCRIPTION
In the HTTP/2 handshake, we expect the server to send a SETTINGS frame right after connecting to it and sending it the connection preface. However, the server can also send a GOAWAY and we were not handling that. Now, we handle the server sending either SETTINGS, GOAWAY, or any other frame with a more graceful error.

Tests for this are just horrible so let's skip them for now.