### PR TITLE
Remove a TODO in Mint.HTTP1

### DIFF
--- a/lib/mint/http1.ex
+++ b/lib/mint/http1.ex
@@ -487,8 +487,7 @@ defmodule Mint.HTTP1 do
         {:ok, conn, responses}
 
       {0, rest} ->
-        # Here, we manually convert the last response to iodata since we're
-        # explicitly moving on to the next request.
+        # Here, we manually collapse the body buffer since we're done with the body.
         {conn, responses} = collapse_body_buffer(conn, responses)
         decode_body({:chunked, :metadata, :trailer}, conn, rest, request_ref, responses)
 

--- a/lib/mint/http1.ex
+++ b/lib/mint/http1.ex
@@ -585,7 +585,6 @@ defmodule Mint.HTTP1 do
 
   defp add_body("", _request_ref, responses), do: responses
 
-  # TODO: Concat binaries or build iodata?
   defp add_body(new_data, request_ref, [{:data, request_ref, data} | responses]),
     do: [{:data, request_ref, data <> new_data} | responses]
 


### PR DESCRIPTION
Turns out that turning the accumulated data into iodata is a PITA because we check the size of the accumulated data quite often with `byte_size`, which then becomes expensive to do. Wdyt @ericmj?