### PR TITLE
Downcase headers when inserting/fetching in HPACK

### DIFF
--- a/lib/mint/core/util.ex
+++ b/lib/mint/core/util.ex
@@ -36,8 +36,9 @@ defmodule Mint.Core.Util do
 
   # Lowercases an ASCII string more efficiently than
   # String.downcase/1.
-  def lower_ascii(string), do: for(<<char <- string>>, do: <<lower_ascii_char(char)>>, into: "")
+  def downcase_ascii(string),
+    do: for(<<char <- string>>, do: <<downcase_ascii_char(char)>>, into: "")
 
-  def lower_ascii_char(char) when char in ?A..?Z, do: char + 32
-  def lower_ascii_char(char) when char in 0..127, do: char
+  def downcase_ascii_char(char) when char in ?A..?Z, do: char + 32
+  def downcase_ascii_char(char) when char in 0..127, do: char
 end

--- a/lib/mint/core/util.ex
+++ b/lib/mint/core/util.ex
@@ -33,4 +33,11 @@ defmodule Mint.Core.Util do
       [{name, value} | headers]
     end
   end
+
+  # Lowercases an ASCII string more efficiently than
+  # String.downcase/1.
+  def lower_ascii(string), do: for(<<char <- string>>, do: <<lower_ascii_char(char)>>, into: "")
+
+  def lower_ascii_char(char) when char in ?A..?Z, do: char + 32
+  def lower_ascii_char(char) when char in 0..127, do: char
 end

--- a/lib/mint/http1/parse.ex
+++ b/lib/mint/http1/parse.ex
@@ -1,6 +1,8 @@
 defmodule Mint.HTTP1.Parse do
   @moduledoc false
 
+  alias Mint.Core.Util
+
   defmacro is_digit(char), do: quote(do: unquote(char) in ?0..?9)
   defmacro is_alpha(char), do: quote(do: unquote(char) in ?a..?z or unquote(char) in ?A..?Z)
   defmacro is_whitespace(char), do: quote(do: unquote(char) in '\s\t')
@@ -12,11 +14,6 @@ defmodule Mint.HTTP1.Parse do
       is_digit(unquote(char)) or is_alpha(unquote(char)) or unquote(char) in '!#$%&\'*+-.^_`|~'
     end
   end
-
-  defp lower_char(char) when char in ?A..?Z, do: char + 32
-  defp lower_char(char), do: char
-
-  def lower(string), do: for(<<char <- string>>, do: <<lower_char(char)>>, into: "")
 
   def ignore_until_crlf(<<>>), do: :more
   def ignore_until_crlf(<<"\r\n", rest::binary>>), do: {:ok, rest}
@@ -58,7 +55,7 @@ defmodule Mint.HTTP1.Parse do
   defp token_list_downcase(rest, acc), do: token_downcase(rest, _token_acc = <<>>, acc)
 
   defp token_downcase(<<char, rest::binary>>, token_acc, acc) when is_tchar(char),
-    do: token_downcase(rest, <<token_acc::binary, lower_char(char)>>, acc)
+    do: token_downcase(rest, <<token_acc::binary, Util.lower_ascii_char(char)>>, acc)
 
   defp token_downcase(rest, token_acc, acc), do: token_list_sep_downcase(rest, [token_acc | acc])
 

--- a/lib/mint/http1/parse.ex
+++ b/lib/mint/http1/parse.ex
@@ -55,7 +55,7 @@ defmodule Mint.HTTP1.Parse do
   defp token_list_downcase(rest, acc), do: token_downcase(rest, _token_acc = <<>>, acc)
 
   defp token_downcase(<<char, rest::binary>>, token_acc, acc) when is_tchar(char),
-    do: token_downcase(rest, <<token_acc::binary, Util.lower_ascii_char(char)>>, acc)
+    do: token_downcase(rest, <<token_acc::binary, Util.downcase_ascii_char(char)>>, acc)
 
   defp token_downcase(rest, token_acc, acc), do: token_list_sep_downcase(rest, [token_acc | acc])
 

--- a/lib/mint/http1/request.ex
+++ b/lib/mint/http1/request.ex
@@ -31,7 +31,7 @@ defmodule Mint.HTTP1.Request do
   end
 
   defp lower_header_keys(headers) do
-    for {name, value} <- headers, do: {Util.lower_ascii(name), value}
+    for {name, value} <- headers, do: {Util.downcase_ascii(name), value}
   end
 
   defp add_default_headers(headers, host, body) do

--- a/lib/mint/http1/request.ex
+++ b/lib/mint/http1/request.ex
@@ -31,7 +31,7 @@ defmodule Mint.HTTP1.Request do
   end
 
   defp lower_header_keys(headers) do
-    for {name, value} <- headers, do: {lower(name), value}
+    for {name, value} <- headers, do: {Util.lower_ascii(name), value}
   end
 
   defp add_default_headers(headers, host, body) do

--- a/lib/mint/http1/response.ex
+++ b/lib/mint/http1/response.ex
@@ -1,7 +1,7 @@
 defmodule Mint.HTTP1.Response do
   @moduledoc false
 
-  alias Mint.HTTP1.Parse
+  alias Mint.Core.Util
 
   def decode_status_line(binary) do
     case :erlang.decode_packet(:http_bin, binary, []) do
@@ -38,6 +38,6 @@ defmodule Mint.HTTP1.Response do
     end
   end
 
-  defp header_name(atom) when is_atom(atom), do: atom |> Atom.to_string() |> Parse.lower()
-  defp header_name(binary) when is_binary(binary), do: Parse.lower(binary)
+  defp header_name(atom) when is_atom(atom), do: atom |> Atom.to_string() |> Util.lower_ascii()
+  defp header_name(binary) when is_binary(binary), do: Util.lower_ascii(binary)
 end

--- a/lib/mint/http1/response.ex
+++ b/lib/mint/http1/response.ex
@@ -38,6 +38,6 @@ defmodule Mint.HTTP1.Response do
     end
   end
 
-  defp header_name(atom) when is_atom(atom), do: atom |> Atom.to_string() |> Util.lower_ascii()
-  defp header_name(binary) when is_binary(binary), do: Util.lower_ascii(binary)
+  defp header_name(atom) when is_atom(atom), do: atom |> Atom.to_string() |> Util.downcase_ascii()
+  defp header_name(binary) when is_binary(binary), do: Util.downcase_ascii(binary)
 end

--- a/lib/mint/http2.ex
+++ b/lib/mint/http2.ex
@@ -466,12 +466,17 @@ defmodule Mint.HTTP2 do
 
   def request(%Mint.HTTP2{} = conn, method, path, headers, body)
       when is_binary(method) and is_binary(path) and is_list(headers) do
+    headers =
+      headers
+      |> downcase_header_names()
+      |> add_default_headers()
+
     headers = [
       {":method", method},
       {":path", path},
       {":scheme", conn.scheme},
       {":authority", "#{conn.hostname}:#{conn.port}"}
-      | add_default_headers(headers)
+      | headers
     ]
 
     {conn, stream_id, ref} = open_stream(conn)
@@ -1187,6 +1192,10 @@ defmodule Mint.HTTP2 do
       {name, _value} ->
         raise ArgumentError, "unknown setting parameter #{inspect(name)}"
     end)
+  end
+
+  defp downcase_header_names(headers) do
+    for {name, value} <- headers, do: {Util.downcase_ascii(name), value}
   end
 
   defp add_default_headers(headers) do

--- a/lib/mint/http2/hpack/table.ex
+++ b/lib/mint/http2/hpack/table.ex
@@ -1,6 +1,8 @@
 defmodule Mint.HTTP2.HPACK.Table do
   @moduledoc false
 
+  alias Mint.Core.Util
+
   defstruct [
     :max_table_size,
     entries: [],
@@ -102,8 +104,8 @@ defmodule Mint.HTTP2.HPACK.Table do
   """
   @spec add(t(), binary(), binary()) :: t()
   def add(%__MODULE__{} = table, name, value) do
-    name = String.downcase(name)
     %{max_table_size: max_table_size, size: size} = table
+    name = Util.lower_ascii(name)
     entry_size = entry_size(name, value)
 
     cond do
@@ -172,7 +174,7 @@ defmodule Mint.HTTP2.HPACK.Table do
   def lookup_by_header(table, name, value)
 
   def lookup_by_header(%__MODULE__{entries: entries}, name, value) do
-    name = String.downcase(name)
+    name = Util.lower_ascii(name)
 
     case static_lookup_by_header(name, value) do
       {:full, _index} = result ->

--- a/lib/mint/http2/hpack/table.ex
+++ b/lib/mint/http2/hpack/table.ex
@@ -190,12 +190,8 @@ defmodule Mint.HTTP2.HPACK.Table do
     end
   end
 
-  defp static_lookup_by_header(name, value) do
-    static_lookup_by_downcased_header(String.downcase(name), value)
-  end
-
   for {{name, value}, index} when is_binary(value) <- Enum.with_index(@static_table, 1) do
-    defp static_lookup_by_downcased_header(unquote(name), unquote(value)) do
+    defp static_lookup_by_header(unquote(name), unquote(value)) do
       {:full, unquote(index)}
     end
   end
@@ -207,12 +203,12 @@ defmodule Mint.HTTP2.HPACK.Table do
     |> Enum.uniq_by(&elem(&1, 0))
 
   for {name, index} <- static_table_names do
-    defp static_lookup_by_downcased_header(unquote(name), _value) do
+    defp static_lookup_by_header(unquote(name), _value) do
       {:name, unquote(index)}
     end
   end
 
-  defp static_lookup_by_downcased_header(_name, _value) do
+  defp static_lookup_by_header(_name, _value) do
     :not_found
   end
 

--- a/test/mint/http2/hpack/table_test.exs
+++ b/test/mint/http2/hpack/table_test.exs
@@ -16,9 +16,6 @@ defmodule HPACK.TableTest do
     assert {:name, _} = Table.lookup_by_header(table, ":authority", nil)
     assert {:name, _} = Table.lookup_by_header(table, ":authority", "https://example.com")
 
-    # The static table is case-insensitive for header names. See #171.
-    assert {:name, _} = Table.lookup_by_header(table, "If-Modified-Since", "some date")
-
     assert Table.lookup_by_header(table, "my-nonexistent-header", nil) == :not_found
     assert Table.lookup_by_header(table, "my-nonexistent-header", "my-value") == :not_found
 
@@ -27,16 +24,6 @@ defmodule HPACK.TableTest do
     assert {:full, _} = Table.lookup_by_header(table, ":my-header", "my-value")
     assert {:name, _} = Table.lookup_by_header(table, ":my-header", "other-value")
     assert {:name, _} = Table.lookup_by_header(table, ":my-header", nil)
-
-    # Perfect match for header name with different case.
-    assert {:full, _} = Table.lookup_by_header(table, ":MY-HEADER", "my-value")
-
-    # Name match for header value with different case.
-    assert {:name, _} = Table.lookup_by_header(table, ":my-header", "MY-VALUE")
-
-    # Adding an uppercase header makes it findable when lowecase.
-    table = Table.add(table, ":OTHER-HEADER", "my-value")
-    assert {:name, _} = Table.lookup_by_header(table, ":other-header", nil)
   end
 
   test "resizing" do

--- a/test/mint/http2/hpack/table_test.exs
+++ b/test/mint/http2/hpack/table_test.exs
@@ -80,7 +80,7 @@ defmodule HPACK.TableTest do
   end
 
   property "adding a header and then looking it up always returns the index of that header" do
-    check all {name, value} <- {binary(min_length: 1), binary()} do
+    check all {name, value} <- {string(0..127, min_length: 1), binary()} do
       assert %Table{} = table = Table.new(10_000)
       assert %Table{} = table = Table.add(table, name, value)
       assert {:full, 62} = Table.lookup_by_header(table, name, value)

--- a/test/mint/http2/hpack/table_test.exs
+++ b/test/mint/http2/hpack/table_test.exs
@@ -16,6 +16,9 @@ defmodule HPACK.TableTest do
     assert {:name, _} = Table.lookup_by_header(table, ":authority", nil)
     assert {:name, _} = Table.lookup_by_header(table, ":authority", "https://example.com")
 
+    # The static table is case-insensitive for header names. See #171.
+    assert {:name, _} = Table.lookup_by_header(table, "If-Modified-Since", "some date")
+
     assert Table.lookup_by_header(table, "my-nonexistent-header", nil) == :not_found
     assert Table.lookup_by_header(table, "my-nonexistent-header", "my-value") == :not_found
 
@@ -24,6 +27,16 @@ defmodule HPACK.TableTest do
     assert {:full, _} = Table.lookup_by_header(table, ":my-header", "my-value")
     assert {:name, _} = Table.lookup_by_header(table, ":my-header", "other-value")
     assert {:name, _} = Table.lookup_by_header(table, ":my-header", nil)
+
+    # Perfect match for header name with different case.
+    assert {:full, _} = Table.lookup_by_header(table, ":MY-HEADER", "my-value")
+
+    # Name match for header value with different case.
+    assert {:name, _} = Table.lookup_by_header(table, ":my-header", "MY-VALUE")
+
+    # Adding an uppercase header makes it findable when lowecase.
+    table = Table.add(table, ":OTHER-HEADER", "my-value")
+    assert {:name, _} = Table.lookup_by_header(table, ":other-header", nil)
   end
 
   test "resizing" do

--- a/test/mint/http2/hpack_test.exs
+++ b/test/mint/http2/hpack_test.exs
@@ -100,7 +100,7 @@ defmodule Mint.HTTP2.HPACKTest do
         {name, value} -> constant({name, value})
       end)
 
-    random_header = {binary(min_length: 1), binary()}
+    random_header = {string(0..127, min_length: 1), binary()}
 
     frequency([
       {1, header_from_static_table},


### PR DESCRIPTION
Before this commit, we would insert headers in the HPACK table without downcasing their name, and we would look up headers without downcasing their name either. With this commit, we downcase header names (since they're case insensitive) before inserting/looking up in the HPACK table.

Closes #171.

@ericmj not sure if there's a better or more efficient way of doing this. We might downcase at the boundary when headers are given to Mint but it's pretty much the same thing I think.