### PR TITLE
Make Mint.HTTP*.get_socket/1 private

### DIFF
--- a/lib/mint/core/conn.ex
+++ b/lib/mint/core/conn.ex
@@ -43,5 +43,6 @@ defmodule Mint.Core.Conn do
 
   @callback delete_private(conn(), key :: atom()) :: conn()
 
+  # Used by proxying. Not public for the user.
   @callback get_socket(conn()) :: Mint.Types.socket()
 end

--- a/lib/mint/http.ex
+++ b/lib/mint/http.ex
@@ -693,19 +693,8 @@ defmodule Mint.HTTP do
   @spec delete_private(t(), atom()) :: t()
   def delete_private(conn, key), do: conn_module(conn).delete_private(conn, key)
 
-  @doc """
-  Gets the underlying TCP/SSL socket from the connection.
-
-  Right now there is no built-in way to tell if the socket being retrieved
-  is a `:gen_tcp` or an `:ssl` socket. You can store the transport (`:http`
-  or `:https`) you're using in the private store when starting the connection.
-  See `put_private/3` and `get_private/3`.
-
-  ## Examples
-
-      socket = Mint.HTTP.get_socket(conn)
-
-  """
+  # Made public to be used with proxying.
+  @doc false
   @impl true
   @spec get_socket(t()) :: Mint.Types.socket()
   def get_socket(conn), do: conn_module(conn).get_socket(conn)

--- a/lib/mint/http1.ex
+++ b/lib/mint/http1.ex
@@ -376,9 +376,8 @@ defmodule Mint.HTTP1 do
     %{conn | private: Map.delete(private, key)}
   end
 
-  @doc """
-  See `Mint.HTTP.get_socket/1`.
-  """
+  # Made public to be used with proxying.
+  @doc false
   @impl true
   @spec get_socket(t()) :: Mint.Types.socket()
   def get_socket(%__MODULE__{socket: socket} = _conn) do

--- a/lib/mint/http2.ex
+++ b/lib/mint/http2.ex
@@ -912,9 +912,8 @@ defmodule Mint.HTTP2 do
     end
   end
 
-  @doc """
-  See `Mint.HTTP.get_socket/1`.
-  """
+  # Made public to be used with proxying.
+  @doc false
   @impl true
   @spec get_socket(t()) :: Mint.Types.socket()
   def get_socket(%Mint.HTTP2{socket: socket} = _conn) do


### PR DESCRIPTION
We should not expose the socket in order to avoid users messing with it. We do need to be able to retrieve the socket from the connections though because we use that when proxying.