### PR TITLE
set_mode/2 and recv/3

### DIFF
--- a/lib/mint/core/conn.ex
+++ b/lib/mint/core/conn.ex
@@ -37,6 +37,12 @@ defmodule Mint.Core.Conn do
 
   @callback open_request_count(conn()) :: non_neg_integer()
 
+  @callback recv(conn(), byte_count :: non_neg_integer(), timeout()) ::
+              {:ok, conn(), [Types.response()]}
+              | {:error, conn(), Types.error(), [Types.response()]}
+
+  @callback set_mode(conn(), :active | :passive) :: {:ok, conn()} | {:error, Types.error()}
+
   @callback put_private(conn(), key :: atom(), value :: term()) :: conn()
 
   @callback get_private(conn(), key :: atom(), default_value :: term()) :: term()

--- a/lib/mint/core/transport.ex
+++ b/lib/mint/core/transport.ex
@@ -23,7 +23,8 @@ defmodule Mint.Core.Transport do
 
   @callback close(Types.socket()) :: :ok | error()
 
-  @callback recv(Types.socket(), bytes :: non_neg_integer()) :: {:ok, binary()} | error()
+  @callback recv(Types.socket(), bytes :: non_neg_integer(), timeout()) ::
+              {:ok, binary()} | error()
 
   @callback setopts(Types.socket(), opts :: keyword()) :: :ok | error()
 

--- a/lib/mint/core/transport/ssl.ex
+++ b/lib/mint/core/transport/ssl.ex
@@ -349,8 +349,8 @@ defmodule Mint.Core.Transport.SSL do
   end
 
   @impl true
-  def recv(socket, bytes) do
-    wrap_err(:ssl.recv(socket, bytes))
+  def recv(socket, bytes, timeout) do
+    wrap_err(:ssl.recv(socket, bytes, timeout))
   end
 
   @impl true

--- a/lib/mint/core/transport/tcp.ex
+++ b/lib/mint/core/transport/tcp.ex
@@ -41,8 +41,8 @@ defmodule Mint.Core.Transport.TCP do
   defdelegate close(socket), to: :gen_tcp
 
   @impl true
-  def recv(socket, bytes) do
-    wrap_err(:gen_tcp.recv(socket, bytes))
+  def recv(socket, bytes, timeout) do
+    wrap_err(:gen_tcp.recv(socket, bytes, timeout))
   end
 
   @impl true

--- a/lib/mint/http.ex
+++ b/lib/mint/http.ex
@@ -649,6 +649,8 @@ defmodule Mint.HTTP do
 
   `timeout` is the maximum time to wait before returning an error.
 
+  This function will raise an error if the socket is active mode.
+
   ## Examples
 
       {:ok, conn, responses} = Mint.HTTP.recv(conn, 0, 5000)

--- a/lib/mint/http.ex
+++ b/lib/mint/http.ex
@@ -87,6 +87,15 @@ defmodule Mint.HTTP do
   doesn't ship with the certificate store itself, but it has an optional dependency on
   [CAStore](https://github.com/ericmj/castore), which provides an up-to-date certificate store. If
   you don't want to use your own certificate store, just add `:castore` to your dependencies.
+
+  ## Mode
+
+  By default Mint operates in **active mode** meaning that the process that started the
+  connection receives socket messages. Mint also supports **passive mode**, where no messages
+  are sent to the process and the process needs to fetch data out of the socket manually.
+  The mode can be controlled at connection time through the `:mode` option in `connect/4`
+  or changed dynamically through `set_mode/2`. Passive mode is generally only recommended
+  for special use cases.
   """
 
   import Mint.Core.Util
@@ -120,6 +129,9 @@ defmodule Mint.HTTP do
     * `:transport_opts` - (keyword) options to be given to the transport being used.
       These options will be merged with some default options that cannot be overridden.
       For more details, refer to the "Transport options" section below.
+
+    * `:mode` - (`:active` or `:passive`) whether to set the socket to active or
+      passive mode. See the "Mode" section in the module documentation and `set_mode/2`.
 
     * `:protocols` - (list of atoms) a list of protocols to try when connecting to the
       server. The possible values in the list are `:http1` for HTTP/1 and HTTP/1.1 and
@@ -184,8 +196,7 @@ defmodule Mint.HTTP do
 
   Common options for `:http` and `:https`:
 
-    * `:active` - managed by Mint. Should not normally be modified by the
-      application at any time.
+    * `:active` - controlled by the `:mode` option. Cannot be overridden.
 
     * `:mode` - set to `:binary`. Cannot be overriden.
 
@@ -519,6 +530,9 @@ defmodule Mint.HTTP do
   it just means that you will process one message at a time with `stream/2` and not
   pay too much attention to the socket mode.
 
+  Mint also supports passive mode to avoid receiving messages. See the "Mode" section
+  in the module documentation.
+
   ## Responses
 
   Each possible response returned by this function is a tuple with two or more elements.
@@ -619,6 +633,58 @@ defmodule Mint.HTTP do
   @impl true
   @spec open_request_count(t()) :: non_neg_integer()
   def open_request_count(conn), do: conn_module(conn).open_request_count(conn)
+
+  @doc """
+  Receives data from the socket in a blocking way.
+
+  By default Mint operates in active mode, meaning that messages are delivered
+  to the process that started the connection. However, Mint also supports passive
+  mode (see the "Mode" section in the module documentation).
+
+  In passive mode, you'll need to manually get bytes out of the socket. You can
+  do that with this function.
+
+  `byte_count` is the number of bytes you want out of the socket. If `byte_count`
+  is `0`, all available bytes will be returned.
+
+  `timeout` is the maximum time to wait before returning an error.
+
+  ## Examples
+
+      {:ok, conn, responses} = Mint.HTTP.recv(conn, 0, 5000)
+
+  """
+  @impl true
+  @spec recv(t(), non_neg_integer(), timeout()) ::
+          {:ok, t(), [Types.response()]}
+          | {:error, t(), Types.error(), [Types.response()]}
+  def recv(conn, byte_count, timeout), do: conn_module(conn).recv(conn, byte_count, timeout)
+
+  @doc """
+  Changes the mode of the underlying socket.
+
+  To use the connection in *active mode*, where the process that started the
+  connection receives socket messages, set the mode to `:active` (see also `stream/2`).
+  To use the connection in *passive mode*, where you need to manually receive data
+  from the socket, set the mode to `:passive` (see also `recv/3`).
+
+  The mode can also be controlled at connection time by the `:mode` option passed
+  to `connect/4`.
+
+  Note that if you're switching from active to passive mode, you still might have
+  socket messages in the process mailbox that you need to consume before doing
+  any other operation on the connection.
+
+  See the "Mode" section in the module documentation for more information on modes.
+
+  ## Examples
+
+      {:ok, conn} = Mint.HTTP.set_mode(conn, :passive)
+
+  """
+  @impl true
+  @spec set_mode(t(), :active | :passive) :: {:ok, t()} | {:error, Types.error()}
+  def set_mode(conn, mode), do: conn_module(conn).set_mode(conn, mode)
 
   @doc """
   Assigns a new private key and value in the connection.

--- a/lib/mint/http.ex
+++ b/lib/mint/http.ex
@@ -649,7 +649,7 @@ defmodule Mint.HTTP do
 
   `timeout` is the maximum time to wait before returning an error.
 
-  This function will raise an error if the socket is active mode.
+  This function will raise an error if the socket is in active mode.
 
   ## Examples
 

--- a/lib/mint/http1.ex
+++ b/lib/mint/http1.ex
@@ -388,7 +388,7 @@ defmodule Mint.HTTP1 do
         :passive -> false
       end
 
-    with :ok <- conn.transport.setopts(conn.socket, active) do
+    with :ok <- conn.transport.setopts(conn.socket, active: active) do
       {:ok, put_in(conn.mode, mode)}
     end
   end

--- a/lib/mint/http1.ex
+++ b/lib/mint/http1.ex
@@ -77,6 +77,7 @@ defmodule Mint.HTTP1 do
     :request,
     :socket,
     :transport,
+    :mode,
     requests: :queue.new(),
     state: :closed,
     buffer: "",
@@ -130,14 +131,21 @@ defmodule Mint.HTTP1 do
           :inet.port_number(),
           keyword()
         ) :: {:ok, t()} | {:error, Types.error()}
-  def initiate(scheme, socket, hostname, _port, _opts) do
+  def initiate(scheme, socket, hostname, _port, opts) do
     transport = scheme_to_transport(scheme)
+    mode = Keyword.get(opts, :mode, :active)
+
+    unless mode in [:active, :passive] do
+      raise ArgumentError,
+            "the :mode option must be either :active or :passive, got: #{inspect(mode)}"
+    end
 
     with :ok <- inet_opts(transport, socket),
-         :ok <- transport.setopts(socket, active: :once) do
+         :ok <- if(mode == :active, do: transport.setopts(socket, active: :once), else: :ok) do
       conn = %__MODULE__{
         transport: transport,
         socket: socket,
+        mode: mode,
         host: hostname,
         state: :open
       }
@@ -284,7 +292,11 @@ defmodule Mint.HTTP1 do
       when tag in [:tcp, :ssl] do
     result = handle_data(conn, data)
     # TODO: handle errors here.
-    _ = transport.setopts(socket, active: :once)
+
+    if conn.mode == :active do
+      _ = transport.setopts(socket, active: :once)
+    end
+
     result
   end
 
@@ -295,9 +307,7 @@ defmodule Mint.HTTP1 do
 
   def stream(%__MODULE__{socket: socket} = conn, {tag, socket, reason})
       when tag in [:tcp_error, :ssl_error] do
-    conn = put_in(conn.state, :closed)
-    error = conn.transport.wrap_error(reason)
-    {:error, conn, error, []}
+    handle_error(conn, reason)
   end
 
   def stream(%__MODULE__{}, _message) do
@@ -331,6 +341,55 @@ defmodule Mint.HTTP1 do
       {:ok, conn, [{:done, request.ref}]}
     else
       {:error, conn, conn.transport.wrap_error(:closed), []}
+    end
+  end
+
+  defp handle_error(conn, reason) do
+    conn = put_in(conn.state, :closed)
+    error = conn.transport.wrap_error(reason)
+    {:error, conn, error, []}
+  end
+
+  @doc """
+  See `Mint.HTTP.recv/3`.
+  """
+  @impl true
+  @spec recv(t(), non_neg_integer(), timeout()) ::
+          {:ok, t(), [Types.response()]}
+          | {:error, t(), Types.error(), [Types.response()]}
+  def recv(conn, byte_count, timeout)
+
+  def recv(%__MODULE__{mode: :passive} = conn, byte_count, timeout) do
+    case conn.transport.recv(conn.socket, byte_count, timeout) do
+      {:ok, data} -> handle_data(conn, data)
+      {:error, reason} -> handle_error(conn, reason)
+    end
+  end
+
+  def recv(_conn, _byte_count, _timeout) do
+    raise ArgumentError,
+          "can't use recv/3 to synchronously receive data when the mode is :active. " <>
+            "Use Mint.HTTP.set_mode/2 to set the connection to passive mode"
+  end
+
+  @doc """
+  See `Mint.HTTP.set_mode/2`.
+  """
+  if Version.match?(System.version(), ">= 1.7.0") do
+    @doc since: "0.3.0"
+  end
+
+  @impl true
+  @spec set_mode(t(), :active | :passive) :: :ok | Types.error()
+  def set_mode(%__MODULE__{} = conn, mode) when mode in [:active, :passive] do
+    active =
+      case mode do
+        :active -> :once
+        :passive -> false
+      end
+
+    with :ok <- conn.transport.setopts(conn.socket, active) do
+      {:ok, put_in(conn.mode, mode)}
     end
   end
 

--- a/lib/mint/http1.ex
+++ b/lib/mint/http1.ex
@@ -291,9 +291,9 @@ defmodule Mint.HTTP1 do
   def stream(%__MODULE__{transport: transport, socket: socket} = conn, {tag, socket, data})
       when tag in [:tcp, :ssl] do
     result = handle_data(conn, data)
-    # TODO: handle errors here.
 
     if conn.mode == :active do
+      # TODO: handle errors here.
       _ = transport.setopts(socket, active: :once)
     end
 

--- a/lib/mint/http2.ex
+++ b/lib/mint/http2.ex
@@ -804,8 +804,12 @@ defmodule Mint.HTTP2 do
   def stream(%Mint.HTTP2{transport: transport, socket: socket} = conn, {tag, socket, data})
       when tag in [:tcp, :ssl] do
     {conn, responses} = handle_new_data(conn, conn.buffer <> data, [])
-    # TODO: handle errors
-    _ = transport.setopts(socket, active: :once)
+
+    if conn.mode == :active do
+      # TODO: handle errors
+      _ = transport.setopts(socket, active: :once)
+    end
+
     {:ok, conn, Enum.reverse(responses)}
   catch
     :throw, {:mint, conn, error, responses} -> {:error, conn, error, responses}

--- a/lib/mint/http2.ex
+++ b/lib/mint/http2.ex
@@ -162,6 +162,7 @@ defmodule Mint.HTTP2 do
     # Transport things.
     :transport,
     :socket,
+    :mode,
 
     # Host things.
     :hostname,
@@ -797,14 +798,7 @@ defmodule Mint.HTTP2 do
 
   def stream(%Mint.HTTP2{socket: socket} = conn, {tag, socket})
       when tag in [:tcp_closed, :ssl_closed] do
-    conn = put_in(conn.state, :closed)
-
-    if conn.open_client_stream_count > 0 or conn.open_server_stream_count > 0 do
-      error = conn.transport.wrap_error(:closed)
-      {:error, conn, error, _responses = []}
-    else
-      {:ok, conn, _responses = []}
-    end
+    handle_closed(conn)
   end
 
   def stream(%Mint.HTTP2{transport: transport, socket: socket} = conn, {tag, socket, data})
@@ -837,6 +831,59 @@ defmodule Mint.HTTP2 do
   @spec open_request_count(t()) :: non_neg_integer()
   def open_request_count(%Mint.HTTP2{} = conn) do
     conn.open_client_stream_count
+  end
+
+  @doc """
+  See `Mint.HTTP.recv/3`.
+  """
+  @impl true
+  @spec recv(t(), non_neg_integer(), timeout()) ::
+          {:ok, t(), [Types.response()]}
+          | {:error, t(), Types.error(), [Types.response()]}
+  def recv(conn, byte_count, timeout)
+
+  def recv(%__MODULE__{mode: :passive} = conn, byte_count, timeout) do
+    case conn.transport.recv(conn.socket, byte_count, timeout) do
+      {:ok, data} ->
+        {conn, responses} = handle_new_data(conn, conn.buffer <> data, [])
+        {:ok, conn, Enum.reverse(responses)}
+
+      {:error, %TransportError{reason: :closed}} ->
+        handle_closed(conn)
+
+      {:error, reason} ->
+        error = conn.transport.wrap_error(reason)
+        {:error, %{conn | state: :closed}, error, _responses = []}
+    end
+  catch
+    :throw, {:mint, conn, error, responses} -> {:error, conn, error, responses}
+  end
+
+  def recv(_conn, _byte_count, _timeout) do
+    raise ArgumentError,
+          "can't use recv/3 to synchronously receive data when the mode is :active. " <>
+            "Use Mint.HTTP.set_mode/2 to set the connection to passive mode"
+  end
+
+  @doc """
+  See `Mint.HTTP.set_mode/2`.
+  """
+  if Version.match?(System.version(), ">= 1.7.0") do
+    @doc since: "0.3.0"
+  end
+
+  @impl true
+  @spec set_mode(t(), :active | :passive) :: :ok | Types.error()
+  def set_mode(%__MODULE__{} = conn, mode) when mode in [:active, :passive] do
+    active =
+      case mode do
+        :active -> :once
+        :passive -> false
+      end
+
+    with :ok <- conn.transport.setopts(conn.socket, active) do
+      {:ok, put_in(conn.mode, mode)}
+    end
   end
 
   @doc """
@@ -879,6 +926,7 @@ defmodule Mint.HTTP2 do
         ) :: {:ok, t()} | {:error, Types.error()}
   def initiate(scheme, socket, hostname, port, opts) do
     transport = scheme_to_transport(scheme)
+    mode = Keyword.get(opts, :mode, :active)
     client_settings_params = Keyword.get(opts, :client_settings, [])
     validate_settings!(client_settings_params)
 
@@ -887,6 +935,7 @@ defmodule Mint.HTTP2 do
       port: port,
       transport: scheme_to_transport(scheme),
       socket: socket,
+      mode: mode,
       scheme: Atom.to_string(scheme),
       state: :open
     }
@@ -921,6 +970,17 @@ defmodule Mint.HTTP2 do
   end
 
   ## Helpers
+
+  defp handle_closed(conn) do
+    conn = put_in(conn.state, :closed)
+
+    if conn.open_client_stream_count > 0 or conn.open_server_stream_count > 0 do
+      error = conn.transport.wrap_error(:closed)
+      {:error, conn, error, _responses = []}
+    else
+      {:ok, conn, _responses = []}
+    end
+  end
 
   defp negotiate(hostname, port, scheme, transport_opts) do
     transport = scheme_to_transport(scheme)
@@ -959,7 +1019,7 @@ defmodule Mint.HTTP2 do
         {:ok, frame, rest, socket}
 
       :more ->
-        with {:ok, data} <- transport.recv(socket, 0) do
+        with {:ok, data} <- transport.recv(socket, 0, _timeout = 10_000) do
           recv_next_frame(transport, socket, buffer <> data)
         end
 

--- a/lib/mint/http2.ex
+++ b/lib/mint/http2.ex
@@ -930,6 +930,11 @@ defmodule Mint.HTTP2 do
     client_settings_params = Keyword.get(opts, :client_settings, [])
     validate_settings!(client_settings_params)
 
+    unless mode in [:active, :passive] do
+      raise ArgumentError,
+            "the :mode option must be either :active or :passive, got: #{inspect(mode)}"
+    end
+
     conn = %Mint.HTTP2{
       hostname: hostname,
       port: port,
@@ -952,7 +957,7 @@ defmodule Mint.HTTP2 do
          conn = put_in(conn.buffer, buffer),
          conn = put_in(conn.socket, socket),
          conn = apply_server_settings(conn, settings(server_settings, :params)),
-         :ok <- transport.setopts(socket, active: :once) do
+         :ok <- if(mode == :active, do: transport.setopts(socket, active: :once), else: :ok) do
       {:ok, conn}
     else
       error ->

--- a/lib/mint/http2.ex
+++ b/lib/mint/http2.ex
@@ -885,7 +885,7 @@ defmodule Mint.HTTP2 do
         :passive -> false
       end
 
-    with :ok <- conn.transport.setopts(conn.socket, active) do
+    with :ok <- conn.transport.setopts(conn.socket, active: active) do
       {:ok, put_in(conn.mode, mode)}
     end
   end

--- a/lib/mint/unsafe_proxy.ex
+++ b/lib/mint/unsafe_proxy.ex
@@ -115,6 +115,25 @@ defmodule Mint.UnsafeProxy do
   end
 
   @impl true
+  @spec recv(t(), non_neg_integer(), timeout()) ::
+          {:ok, t(), [Types.response()]}
+          | {:error, t(), Types.error(), [Types.response()]}
+  def recv(%UnsafeProxy{module: module, state: state} = conn, byte_count, timeout) do
+    case module.recv(state, byte_count, timeout) do
+      {:ok, state, responses} -> {:ok, %{conn | state: state}, responses}
+      {:error, state, reason, responses} -> {:error, %{conn | state: state}, reason, responses}
+    end
+  end
+
+  @impl true
+  @spec set_mode(t(), :active | :passive) :: {:ok, t()} | {:error, Types.error()}
+  def set_mode(%UnsafeProxy{module: module, state: state} = conn, mode) do
+    with {:ok, state} <- module.set_mode(state, mode) do
+      {:ok, %{conn | state: state}}
+    end
+  end
+
+  @impl true
   @spec put_private(t(), atom(), term()) :: t()
   def put_private(%UnsafeProxy{module: module, state: state} = conn, key, value) do
     state = module.put_private(state, key, value)

--- a/test/mint/http1/conn_properties_test.exs
+++ b/test/mint/http1/conn_properties_test.exs
@@ -7,8 +7,9 @@ defmodule Mint.HTTP1.PropertiesTest do
   alias Mint.{HTTP1, HTTP1.TestServer}
 
   setup do
-    {:ok, port} = TestServer.start()
+    {:ok, port, server_ref} = TestServer.start()
     assert {:ok, conn} = HTTP1.connect(:http, "localhost", port)
+    assert_receive {^server_ref, _server_socket}
     [conn: conn]
   end
 

--- a/test/mint/http1/conn_test.exs
+++ b/test/mint/http1/conn_test.exs
@@ -6,7 +6,7 @@ defmodule Mint.HTTP1Test do
   setup do
     {:ok, port} = TestServer.start()
     assert {:ok, conn} = HTTP1.connect(:http, "localhost", port)
-    [conn: conn]
+    [conn: conn, port: port]
   end
 
   test "unknown message", %{conn: conn} do
@@ -303,5 +303,11 @@ defmodule Mint.HTTP1Test do
 
     assert {:ok, conn, _responses} = HTTP1.stream(conn, {:tcp, conn.socket, response})
     assert HTTP1.open_request_count(conn) == 0
+  end
+
+  test "connect/4 raises if :mode is not :active/:passive", %{port: port} do
+    assert_raise ArgumentError, ~r/^the :mode option .* got: :something_else$/, fn ->
+      HTTP1.connect(:http, "localhost", port, mode: :something_else)
+    end
   end
 end

--- a/test/mint/http1/conn_test.exs
+++ b/test/mint/http1/conn_test.exs
@@ -4,9 +4,11 @@ defmodule Mint.HTTP1Test do
   alias Mint.{HTTPError, HTTP1, HTTP1.TestServer}
 
   setup do
-    {:ok, port} = TestServer.start()
+    {:ok, port, server_ref} = TestServer.start()
     assert {:ok, conn} = HTTP1.connect(:http, "localhost", port)
-    [conn: conn, port: port]
+    assert_receive {^server_ref, server_socket}
+
+    [conn: conn, port: port, server_ref: server_ref, server_socket: server_socket]
   end
 
   test "unknown message", %{conn: conn} do
@@ -309,5 +311,34 @@ defmodule Mint.HTTP1Test do
     assert_raise ArgumentError, ~r/^the :mode option .* got: :something_else$/, fn ->
       HTTP1.connect(:http, "localhost", port, mode: :something_else)
     end
+  end
+
+  test "starting a connection in :passive mode and using recv/3",
+       %{port: port, server_ref: server_ref} do
+    assert {:ok, conn} = HTTP1.connect(:http, "localhost", port, mode: :passive)
+    assert_receive {^server_ref, server_socket}
+
+    {:ok, conn, ref} = HTTP1.request(conn, "GET", "/", [], nil)
+
+    :ok = :gen_tcp.send(server_socket, "HTTP/1.1 200 OK\r\n")
+
+    assert {:ok, _conn, responses} = HTTP1.recv(conn, 0, 100)
+    assert responses == [{:status, ref, 200}]
+  end
+
+  test "changing the connection mode with set_mode/2",
+       %{conn: conn, server_socket: server_socket} do
+    assert_raise ArgumentError, ~r"can't use recv/3", fn ->
+      HTTP1.recv(conn, 0, 100)
+    end
+
+    assert {:ok, conn} = HTTP1.set_mode(conn, :passive)
+
+    {:ok, conn, ref} = HTTP1.request(conn, "GET", "/", [], nil)
+
+    :ok = :gen_tcp.send(server_socket, "HTTP/1.1 200 OK\r\n")
+
+    assert {:ok, _conn, responses} = HTTP1.recv(conn, 0, 100)
+    assert responses == [{:status, ref, 200}]
   end
 end

--- a/test/support/mint/http1/test_server.ex
+++ b/test/support/mint/http1/test_server.ex
@@ -1,14 +1,24 @@
 defmodule Mint.HTTP1.TestServer do
   def start() do
     {:ok, listen_socket} = :gen_tcp.listen(0, mode: :binary, packet: :raw)
-    spawn_link(fn -> loop(listen_socket) end)
-    :inet.port(listen_socket)
+    server_ref = make_ref()
+    parent = self()
+
+    spawn_link(fn -> loop(listen_socket, parent, server_ref) end)
+
+    with {:ok, port} <- :inet.port(listen_socket) do
+      {:ok, port, server_ref}
+    end
   end
 
-  defp loop(listen_socket) do
+  defp loop(listen_socket, parent, server_ref) do
     case :gen_tcp.accept(listen_socket) do
-      {:ok, _socket} -> loop(listen_socket)
-      {:error, :closed} -> :ok
+      {:ok, socket} ->
+        send(parent, {server_ref, socket})
+        loop(listen_socket, parent, server_ref)
+
+      {:error, :closed} ->
+        :ok
     end
   end
 end

--- a/test/support/mint/http2/test_server.ex
+++ b/test/support/mint/http2/test_server.ex
@@ -30,8 +30,15 @@ defmodule Mint.HTTP2.TestServer do
     {:ok, server_socket} = Task.await(task)
 
     # SETTINGS here.
-    assert_receive message, 100
-    assert {:ok, %HTTP2{} = conn, []} = HTTP2.stream(conn, message)
+    conn =
+      if options[:mode] == :passive do
+        assert {:ok, %HTTP2{} = conn, []} = HTTP2.recv(conn, 0, 100)
+        conn
+      else
+        assert_receive message, 100
+        assert {:ok, %HTTP2{} = conn, []} = HTTP2.stream(conn, message)
+        conn
+      end
 
     :ok = :ssl.setopts(server_socket, active: true)
 


### PR DESCRIPTION
This PR adds support for "passive mode" to the connections. The `:mode` option can be used when connecting to set the mode to `:active` (default) or `:passive`. `set_mode/2` can be used to change the mode of a connection. `recv/3` can be used in passive mode to receive data from the socket.

Closes #170.