### PR TITLE
Prevented unnecessary buffer allocation

### DIFF
--- a/lib/mint/core/util.ex
+++ b/lib/mint/core/util.ex
@@ -41,4 +41,10 @@ defmodule Mint.Core.Util do
 
   def downcase_ascii_char(char) when char in ?A..?Z, do: char + 32
   def downcase_ascii_char(char) when char in 0..127, do: char
+
+  # If the buffer is empty, reusing the incoming data saves
+  # a potentially large allocation of memory.
+  # This should be fixed in a subsequent OTP release.
+  def maybe_concat(<<>>, data), do: data
+  def maybe_concat(buffer, data) when is_binary(buffer), do: buffer <> data
 end

--- a/lib/mint/http1.ex
+++ b/lib/mint/http1.ex
@@ -320,7 +320,13 @@ defmodule Mint.HTTP1 do
   end
 
   defp handle_data(%__MODULE__{request: request} = conn, data) do
-    data = conn.buffer <> data
+    # If the buffer is empty, reusing the incoming data saves
+    # a potentially large allocation of memory
+    data =
+      case conn.buffer do
+        <<>> -> data
+        buffer -> buffer <> data
+      end
 
     case decode(request.state, conn, data, []) do
       {:ok, conn, responses} ->

--- a/lib/mint/http1.ex
+++ b/lib/mint/http1.ex
@@ -320,13 +320,7 @@ defmodule Mint.HTTP1 do
   end
 
   defp handle_data(%__MODULE__{request: request} = conn, data) do
-    # If the buffer is empty, reusing the incoming data saves
-    # a potentially large allocation of memory
-    data =
-      case conn.buffer do
-        <<>> -> data
-        buffer -> buffer <> data
-      end
+    data = maybe_concat(conn.buffer, data)
 
     case decode(request.state, conn, data, []) do
       {:ok, conn, responses} ->


### PR DESCRIPTION
If the existing body buffer is empty, we can safely set the incoming body to
be the initial state of that buffer. This prevents a rather slow
allocation from taking place.
In my testing in a database driver, this speeds up the query's
response processing by over two seconds.