### PR TITLE
Add support for chunked transfer-encoding in HTTP/1 requests

### DIFF
--- a/lib/mint/http1.ex
+++ b/lib/mint/http1.ex
@@ -843,7 +843,7 @@ defmodule Mint.HTTP1 do
         {"transfer-encoding", value} = found
 
         with {:ok, tokens} <- Parse.transfer_encoding_header(value) do
-          if "chunked" in tokens do
+          if "chunked" in tokens or "identity" in tokens do
             {:ok, headers, :identity}
           else
             new_transfer_encoding = {"transfer-encoding", value <> ",chunked"}

--- a/lib/mint/http1/request.ex
+++ b/lib/mint/http1/request.ex
@@ -10,7 +10,6 @@ defmodule Mint.HTTP1.Request do
   def encode(method, target, host, headers, body) do
     headers =
       headers
-      |> lower_header_keys()
       |> add_default_headers(host, body)
 
     body = [
@@ -28,10 +27,6 @@ defmodule Mint.HTTP1.Request do
   defp encode_request_line(method, target) do
     validate_target!(target)
     [method, ?\s, target, " HTTP/1.1\r\n"]
-  end
-
-  defp lower_header_keys(headers) do
-    for {name, value} <- headers, do: {Util.downcase_ascii(name), value}
   end
 
   defp add_default_headers(headers, host, body) do
@@ -61,6 +56,14 @@ defmodule Mint.HTTP1.Request do
   defp encode_body(nil), do: ""
   defp encode_body(:stream), do: ""
   defp encode_body(body), do: body
+
+  def encode_chunk(chunk) when is_binary(chunk) do
+    [Integer.to_string(byte_size(chunk), 16), "\r\n", chunk, "\r\n"]
+  end
+
+  def encode_chunk(:eof) do
+    "0\r\n\r\n"
+  end
 
   # Percent-encoding is not case sensitive so we have to account for lowercase and uppercase.
   @hex_characters '0123456789abcdefABCDEF'

--- a/test/mint/http1/conn_test.exs
+++ b/test/mint/http1/conn_test.exs
@@ -432,7 +432,6 @@ defmodule Mint.HTTP1Test do
   end
 
   describe "streaming requests" do
-    @describetag :focus
     test "transfer-encoding is set to chunked if not set already, and content is chunked",
          %{conn: conn, server_socket: server_socket} do
       {:ok, conn, ref} = HTTP1.request(conn, "GET", "/", [], :stream)

--- a/test/mint/http1/request_test.exs
+++ b/test/mint/http1/request_test.exs
@@ -1,91 +1,83 @@
 defmodule Mint.HTTP1.RequestTest do
   use ExUnit.Case, async: true
+  use ExUnitProperties
 
   alias Mint.HTTP1.Request
 
   describe "encode/5" do
     test "with header" do
-      assert encode_request("GET", "/", "example.com", [{"foo", "bar"}], nil) ==
+      assert encode_request("GET", "/", [{"foo", "bar"}], nil) ==
                request_string("""
                GET / HTTP/1.1
-               host: example.com
-               user-agent: mint/#{Mix.Project.config()[:version]}
                foo: bar
 
                """)
     end
 
     test "with body" do
-      assert encode_request("GET", "/", "example.com", [], "BODY") ==
+      assert encode_request("GET", "/", [], "BODY") ==
                request_string("""
                GET / HTTP/1.1
-               host: example.com
-               user-agent: mint/#{Mix.Project.config()[:version]}
-               content-length: 4
 
                BODY\
                """)
     end
 
-    test "with overridden content-length" do
-      assert encode_request("GET", "/", "example.com", [{"content-length", "10"}], "BODY") ==
+    test "with body and headers" do
+      assert encode_request("POST", "/some-url", [{"foo", "bar"}], "hello!") ==
                request_string("""
-               GET / HTTP/1.1
-               host: example.com
-               user-agent: mint/#{Mix.Project.config()[:version]}
-               content-length: 10
+               POST /some-url HTTP/1.1
+               foo: bar
 
-               BODY\
-               """)
-    end
-
-    test "with overridden user-agent" do
-      assert encode_request("GET", "/", "example.com", [{"user-agent", "myapp/1.0"}], "BODY") ==
-               request_string("""
-               GET / HTTP/1.1
-               host: example.com
-               content-length: 4
-               user-agent: myapp/1.0
-
-               BODY\
-               """)
-    end
-
-    test "override with non-lowercase key" do
-      assert encode_request("GET", "/", "example.com", [{"User-Agent", "myapp/1.0"}], "BODY") ==
-               request_string("""
-               GET / HTTP/1.1
-               host: example.com
-               content-length: 4
-               user-agent: myapp/1.0
-
-               BODY\
+               hello!\
                """)
     end
 
     test "validates request target" do
       for invalid_target <- ["/ /", "/%foo", "/foo%x"] do
-        assert Request.encode("GET", invalid_target, "example.com", [], nil) ==
+        assert Request.encode("GET", invalid_target, [], nil) ==
                  {:error, {:invalid_request_target, invalid_target}}
       end
 
-      request = encode_request("GET", "/foo%20bar", "example.com", [], nil)
+      request = encode_request("GET", "/foo%20bar", [], nil)
       assert String.starts_with?(request, request_string("GET /foo%20bar HTTP/1.1"))
     end
 
     test "invalid header name" do
-      assert Request.encode("GET", "/", "example.com", [{"f oo", "bar"}], nil) ==
+      assert Request.encode("GET", "/", [{"f oo", "bar"}], nil) ==
                {:error, {:invalid_header_name, "f oo"}}
     end
 
     test "invalid header value" do
-      assert Request.encode("GET", "/", "example.com", [{"foo", "bar\r\n"}], nil) ==
+      assert Request.encode("GET", "/", [{"foo", "bar\r\n"}], nil) ==
                {:error, {:invalid_header_value, "foo", "bar\r\n"}}
     end
   end
 
-  defp encode_request(method, target, host, headers, body) do
-    assert {:ok, iodata} = Request.encode(method, target, host, headers, body)
+  describe "encode_chunk/1" do
+    test ":eof" do
+      assert IO.iodata_to_binary(Request.encode_chunk(:eof)) == "0\r\n\r\n"
+    end
+
+    test "iodata" do
+      iodata = "foo"
+      assert IO.iodata_to_binary(Request.encode_chunk(iodata)) == "3\r\nfoo\r\n"
+
+      iodata = ["hello ", ?w, [["or"], ?l], ?d]
+      assert IO.iodata_to_binary(Request.encode_chunk(iodata)) == "B\r\nhello world\r\n"
+    end
+
+    property "encoded chunk always contains at least two CRLFs" do
+      check all iodata <- iodata() do
+        encoded = iodata |> Request.encode_chunk() |> IO.iodata_to_binary()
+        assert String.ends_with?(encoded, "\r\n")
+        assert encoded |> String.replace_suffix("\r\n", "") |> String.contains?("\r\n")
+      end
+    end
+  end
+
+  defp encode_request(method, target, headers, body) do
+    assert {:ok, iodata} = Request.encode(method, target, headers, body)
     IO.iodata_to_binary(iodata)
   end
 

--- a/test/support/mint/http1/test_server.ex
+++ b/test/support/mint/http1/test_server.ex
@@ -15,6 +15,7 @@ defmodule Mint.HTTP1.TestServer do
     case :gen_tcp.accept(listen_socket) do
       {:ok, socket} ->
         send(parent, {server_ref, socket})
+        :ok = :gen_tcp.controlling_process(socket, parent)
         loop(listen_socket, parent, server_ref)
 
       {:error, :closed} ->


### PR DESCRIPTION
Based off of @ericmj's work, I:

* moved all the request header handling logic from `HTTP1.Request` to `HTTP1`. This means that now `Request` is really dumb and its only job is to encode method/path/headers/body. Easy to test and reason about. I love it.
* handled the case where a user already has a `transfer-encoding` header but it doesn't contain `chunked` or `identity`
* added tests for all of this stuff