### PR TITLE
Catch connection errors in Mint.HTTP2.connect/4

### DIFF
--- a/lib/mint/http2.ex
+++ b/lib/mint/http2.ex
@@ -991,6 +991,10 @@ defmodule Mint.HTTP2 do
         transport.close(socket)
         error
     end
+  catch
+    {:mint, conn, error} ->
+      {:ok, _conn} = close(conn)
+      {:error, error}
   end
 
   # Made public to be used with proxying.

--- a/test/mint/http2/conn_test.exs
+++ b/test/mint/http2/conn_test.exs
@@ -1082,6 +1082,14 @@ defmodule Mint.HTTP2Test do
       assert_recv_frames [settings(flags: flags)]
       assert flags == set_flags(:settings, [:ack])
     end
+
+    # TODO: We're skipping this test for now because we need to find a good way
+    # to assert on the errors that might be returned by HTTP2.connect/4. Right
+    # now the connect/4 calls happens when setting up the connection to the test
+    # server and we assert that a successful connection is established in that code.
+    # An example of an invalid setting is "max_frame_size: 1".
+    @tag :skip
+    test "protocol error when server sends an invalid setting"
   end
 
   describe "stream_request_body/3" do


### PR DESCRIPTION
`Mint.HTTP2.connect/4` (which calls `initiate/5`) was not catching thrown errors from functions used inside it (such as `apply_server_settings`). This commit fixes that and adds the stub of a test (read test comment for more explanation on why it's a stub).