### PR TITLE
Add decompression guide

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -27,7 +27,10 @@ defmodule Mint.MixProject do
       docs: [
         source_ref: "v#{@version}",
         source_url: @repo_url,
-        extras: ["pages/Architecture.md"]
+        extras: [
+          "pages/Architecture.md",
+          "pages/Decompression.md"
+        ]
       ]
     ]
   end

--- a/pages/Decompression.md
+++ b/pages/Decompression.md
@@ -1,0 +1,115 @@
+# Decompression
+
+Many web servers use compression to reduce the size of the payload to speed up
+delivery to clients, expecting clients to decompress the body of the request.
+The common compression algorithms used are [gzip], [brotli], [deflate], or no
+compression at all.
+
+Clients may specify acceptable compression algorithms in an HTTP header
+`accept-encoding`. It's normal for clients to supply one or more values in
+[Accept-Encoding], eg: `Accept-Encoding: gzip, deflate, identity` in the order
+of preference.
+
+Servers will read the `accept-encoding` header, and respond appropriately
+indicating which compression is used in the response body with the header
+[Content-Encoding]. It's not as common to use multiple compression algorithms,
+but it is possible; eg: `Content-Encoding: gzip` or `Content-Encoding: br, gzip`
+meaning it was compressed with br first, and then gzip.
+
+[gzip]: https://tools.ietf.org/html/rfc1952
+[brotli]: https://tools.ietf.org/html/rfc7932
+[deflate]: https://tools.ietf.org/html/rfc1951
+[Accept-Encoding]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept-Encoding
+[Content-Encoding]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Encoding
+
+## Example
+
+Starting with the [architecture example](architecture.html#content), we're going add
+some logic to handle a finished request's compressed body. This is where we
+start:
+
+```elixir
+defp process_response({:done, request_ref}, state) do
+  {%{response: response, from: from}, state} = pop_in(state.requests[request_ref])
+  GenServer.reply(from, {:ok, response})
+  state
+end
+```
+
+This function handles the response back to the blocked process that's waiting
+for the HTTP response. You'll see that it returns `{:ok, response}` with
+`response` containing `:data, :headers, :status` keys.
+
+We need to attempt to decompress the data if `content-encoding` header is
+present; first we're going to find the header. Let's add a function:
+
+```elixir
+# Passing in response.headers
+# Returns a list of found compressions or [] if none found.
+defp find_content_encoding(headers) do
+  Enum.find_value(
+    headers,
+    [],
+    fn {name, value} ->
+      if String.downcase(name) == "content-encoding" do
+        value
+        |> String.downcase()
+        |> String.replace(~r|\s|, "")
+        |> String.split(",")
+        |> Enum.reverse()
+      end
+    end
+  )
+end
+```
+
+Now we should have a list like `["gzip"]`. Let's use this in another function
+that handles the decompression. Thankfully, Erlang ships with built-in support
+for gzip and deflate algorithms.
+
+```elixir
+# Passing in response.data and compressions we found above
+# returns the decompressed body or unmodified body.
+defp decompress_data(data, []), do: data
+defp decompress_data(data, ["gzip" | rest]), do:
+  data |> :zlib.gunzip() |> decompress_data(rest)
+defp decompress_data(data, ["x-gzip" | rest]), do:
+  data |> :zlib.gunzip() |> decompress_data(rest)
+defp decompress_data(data, ["deflate" | rest]), do:
+  data |> :zlib.unzip() |> decompress_data(rest)
+defp decompress_data(data, ["identity" | rest]), do:
+  decompress_data(data, rest)
+defp decompress_data(data, [encoding | _rest]) do
+  Logger.info "Could not decompress body with #{encoding}"
+  # Let's also stop decompressing, since it won't work from this point on
+  data
+end
+```
+
+If there are no compressions, then the body just returns. Otherwise, we'll take
+the first algorithm in the list and try to decompress the body. That
+decompressed body will then be passed into the function again with the remaining
+compressions until there are no more remaining. In case you come across an
+unsupported algorithm, you might want to log or raise an exception so you can
+see where you may be lacking support.
+
+Now let's put it together. We can use these new functions when the request is
+done and pass the result back to the client.
+
+```elixir
+defp process_response({:done, request_ref}, state) do
+  {%{response: response, from: from}, state} = pop_in(state.requests[request_ref])
+
+  # added these two lines:
+  decompressed = decompress_data(response.data, find_content_encoding(response.headers))
+  response = %{response | data: decompressed}
+
+  GenServer.reply(from, {:ok, response})
+  state
+end
+```
+
+Now you can decompress responses! Above is a simple approach to a potentially
+complex response, so there is room for error (for example, this guide does not
+handle decompression errors). If you see room for improvement in this guide,
+please submit a PR!

--- a/pages/Decompression.md
+++ b/pages/Decompression.md
@@ -54,7 +54,7 @@ defp decompress_with_algorithm(gzip, data) when gzip in ["gzip", "x-gzip"],
   do: :zlip.gunzip(data)
 
 defp decompress_with_algorithm("deflate", data),
-  do: :zlip.unzip(data)
+  do: :zlib.unzip(data)
 
 defp decompress_data("identity", data),
   do: data

--- a/pages/Decompression.md
+++ b/pages/Decompression.md
@@ -4,7 +4,7 @@ Many web servers use compression to reduce the size of the payload to speed up d
 
 Clients may specify acceptable compression algorithms through the [`accept-encoding`][accept-encoding] request header. It's common for clients to supply one or more values in `accept-encoding`, for example `accept-encoding: gzip, deflate, identity` in the order of preference.
 
-Servers will read the `accept-encoding` header, and respond appropriately indicating which compression is used in the response body through the [`content-encoding`][content-encoding] or [`transfer-encoding`][transfer-encoding] response headers. It's not as common to use multiple compression algorithms, but it is possible: for example, `content-encoding: gzip` or `content-encoding: br, gzip` (meaning it was compressed with `br` first, and then `gzip`).
+Servers will read the `accept-encoding` and `TE` request headers, and respond appropriately indicating which compression is used in the response body through the [`content-encoding`][content-encoding] or [`transfer-encoding`][transfer-encoding] response headers respectively. It's not as common to use multiple compression algorithms, but it is possible: for example, `content-encoding: gzip` or `content-encoding: br, gzip` (meaning it was compressed with `br` first, and then `gzip`).
 
 Mint is a low-level client so it doesn't have built-in support for decompression. In this guide we'll explore how to add support for decompression when using Mint.
 

--- a/pages/Decompression.md
+++ b/pages/Decompression.md
@@ -1,115 +1,92 @@
 # Decompression
 
-Many web servers use compression to reduce the size of the payload to speed up
-delivery to clients, expecting clients to decompress the body of the request.
-The common compression algorithms used are [gzip], [brotli], [deflate], or no
-compression at all.
+Many web servers use compression to reduce the size of the payload to speed up delivery to clients, expecting clients to decompress the body of the request. Some of the common compression algorithms used are [gzip], [brotli], [deflate], or no compression at all.
 
-Clients may specify acceptable compression algorithms in an HTTP header
-`accept-encoding`. It's normal for clients to supply one or more values in
-[Accept-Encoding], eg: `Accept-Encoding: gzip, deflate, identity` in the order
-of preference.
+Clients may specify acceptable compression algorithms through the [`accept-encoding`][accept-encoding] request header. It's common for clients to supply one or more values in `accept-encoding`, for example `accept-encoding: gzip, deflate, identity` in the order of preference.
 
-Servers will read the `accept-encoding` header, and respond appropriately
-indicating which compression is used in the response body with the header
-[Content-Encoding]. It's not as common to use multiple compression algorithms,
-but it is possible; eg: `Content-Encoding: gzip` or `Content-Encoding: br, gzip`
-meaning it was compressed with br first, and then gzip.
+Servers will read the `accept-encoding` header, and respond appropriately indicating which compression is used in the response body through the [`content-encoding`][content-encoding] or [`transfer-encoding`][transfer-encoding] response headers. It's not as common to use multiple compression algorithms, but it is possible: for example, `content-encoding: gzip` or `content-encoding: br, gzip` (meaning it was compressed with `br` first, and then `gzip`).
+
+Mint is a low-level client so it doesn't have built-in support for decompression. In this guide we'll explore how to add support for decompression when using Mint.
+
+## Decompressing the response body
+
+Starting with the [architecture example](architecture.html#content), we're going add some logic to handle a finished request's compressed body. With some compression algorithms, it's possible to decompress body chunks as they come (in a streaming way), but let's look at an example that works for every compression algorithm by decompressing the whole response body when the response is done.
+
+This is where we start:
+
+```elixir
+defp process_response({:done, request_ref}, state) do
+  {%{response: response, from: from}, state} = pop_in(state.requests[request_ref])
+  GenServer.reply(from, {:ok, response})
+  state
+end
+```
+
+This function handles the response back to the blocked process that's waiting for the HTTP response. You'll see that it returns `{:ok, response}` with `response` being a map with `:status`, `:headers`, and `:data` fields.
+
+We need to attempt to decompress the data if the `content-encoding` header is present. We're going to work with `content-encoding`, but the same applies if compression is used in  `transfer-encoding`. First, we're going to find the header. Let's add a function to do that:
+
+```elixir
+# Returns a list of found compressions or [] if none found.
+defp get_content_encoding_header(headers) do
+  Enum.find_value(headers, [], fn {name, value} ->
+    if String.downcase(name) == "content-encoding" do
+      value
+      |> String.downcase()
+      |> String.split(",", trim: true)
+      |> Stream.map(&String.trim/1)
+      |> Enum.reverse()
+    else
+      nil
+    end
+  end)
+end
+```
+
+Now we should have a list like `["gzip"]`. We reversed the compression algorithms so that we decompress from the last one to the first one. Let's use this in another function that handles the decompression. Thankfully, Erlang ships with built-in support for gzip and deflate algorithms.
+
+```elixir
+defp decompress_data(data, algorithms) do
+  Enum.reduce(algorithms, data, &decompress_with_algorithm/2)
+end
+
+defp decompress_with_algorithm(gzip, data) when gzip in ["gzip", "x-gzip"],
+  do: :zlip.gunzip(data)
+
+defp decompress_with_algorithm("deflate", data),
+  do: :zlip.unzip(data)
+
+defp decompress_data("identity", data),
+  do: data
+
+defp decompress_data(algorithm, data),
+  do: raise "unsupported decompression algorithm: #{inspect(algorithm)}"
+```
+
+In case you come across an unsupported algorithm, you might want to log or raise an exception so you can see where you may be lacking support.
+
+Now let's put it together. We can use these new functions when the request is done and pass the result back to the client.
+
+```elixir
+defp process_response({:done, request_ref}, state) do
+  {%{response: response, from: from}, state} = pop_in(state.requests[request_ref])
+
+  # Handle compression here.
+  compression_algorithms = get_content_encoding_header(response.headers)
+  response = update_in(response.data, &decompress_data(&1, compression_algorithms))
+
+  GenServer.reply(from, {:ok, response})
+
+  state
+end
+```
+
+Now you can decompress responses! Above is a simple approach to a potentially complex response, so there is room for error. For example, this guide does not handle decompression errors or compression through `transfer-encoding` (although the code stays very similar in that case).
+
 
 [gzip]: https://tools.ietf.org/html/rfc1952
 [brotli]: https://tools.ietf.org/html/rfc7932
 [deflate]: https://tools.ietf.org/html/rfc1951
-[Accept-Encoding]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept-Encoding
-[Content-Encoding]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Encoding
-
-## Example
-
-Starting with the [architecture example](architecture.html#content), we're going add
-some logic to handle a finished request's compressed body. This is where we
-start:
-
-```elixir
-defp process_response({:done, request_ref}, state) do
-  {%{response: response, from: from}, state} = pop_in(state.requests[request_ref])
-  GenServer.reply(from, {:ok, response})
-  state
-end
-```
-
-This function handles the response back to the blocked process that's waiting
-for the HTTP response. You'll see that it returns `{:ok, response}` with
-`response` containing `:data, :headers, :status` keys.
-
-We need to attempt to decompress the data if `content-encoding` header is
-present; first we're going to find the header. Let's add a function:
-
-```elixir
-# Passing in response.headers
-# Returns a list of found compressions or [] if none found.
-defp find_content_encoding(headers) do
-  Enum.find_value(
-    headers,
-    [],
-    fn {name, value} ->
-      if String.downcase(name) == "content-encoding" do
-        value
-        |> String.downcase()
-        |> String.replace(~r|\s|, "")
-        |> String.split(",")
-        |> Enum.reverse()
-      end
-    end
-  )
-end
-```
-
-Now we should have a list like `["gzip"]`. Let's use this in another function
-that handles the decompression. Thankfully, Erlang ships with built-in support
-for gzip and deflate algorithms.
-
-```elixir
-# Passing in response.data and compressions we found above
-# returns the decompressed body or unmodified body.
-defp decompress_data(data, []), do: data
-defp decompress_data(data, ["gzip" | rest]), do:
-  data |> :zlib.gunzip() |> decompress_data(rest)
-defp decompress_data(data, ["x-gzip" | rest]), do:
-  data |> :zlib.gunzip() |> decompress_data(rest)
-defp decompress_data(data, ["deflate" | rest]), do:
-  data |> :zlib.unzip() |> decompress_data(rest)
-defp decompress_data(data, ["identity" | rest]), do:
-  decompress_data(data, rest)
-defp decompress_data(data, [encoding | _rest]) do
-  Logger.info "Could not decompress body with #{encoding}"
-  # Let's also stop decompressing, since it won't work from this point on
-  data
-end
-```
-
-If there are no compressions, then the body just returns. Otherwise, we'll take
-the first algorithm in the list and try to decompress the body. That
-decompressed body will then be passed into the function again with the remaining
-compressions until there are no more remaining. In case you come across an
-unsupported algorithm, you might want to log or raise an exception so you can
-see where you may be lacking support.
-
-Now let's put it together. We can use these new functions when the request is
-done and pass the result back to the client.
-
-```elixir
-defp process_response({:done, request_ref}, state) do
-  {%{response: response, from: from}, state} = pop_in(state.requests[request_ref])
-
-  # added these two lines:
-  decompressed = decompress_data(response.data, find_content_encoding(response.headers))
-  response = %{response | data: decompressed}
-
-  GenServer.reply(from, {:ok, response})
-  state
-end
-```
-
-Now you can decompress responses! Above is a simple approach to a potentially
-complex response, so there is room for error (for example, this guide does not
-handle decompression errors). If you see room for improvement in this guide,
-please submit a PR!
+[accept-encoding]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept-Encoding
+[content-encoding]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Encoding
+[transfer-encoding]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Transfer-Encoding


### PR DESCRIPTION
Resolves #183 

This adds a guide on how to deal with compressed response bodies.

[view rendered guide](https://github.com/dbernheisel/mint/blob/db-add-decompression-guide/pages/Decompression.md)

I also have a small [example repo](https://github.com/dbernheisel/mint_decompression_example) if anyone wants to see code that decompresses `gzip` and `deflate` responses (though it's really difficult to find a live example of a server that serves up using `deflate`, so only `gzip` is tested).

I think it's possible to decompress the gzipped data as it comes, opposed to all at once at the end, but I'll reserve that for another PR.