### PR TITLE
Handle unallowed trailing headers

### DIFF
--- a/lib/mint/core/util.ex
+++ b/lib/mint/core/util.ex
@@ -100,7 +100,7 @@ defmodule Mint.Core.Util do
   def remove_unallowed_trailing_headers(headers) do
     # TODO: don't downcase here, downcase all headers as soon as we parse them instead.
     Enum.reject(headers, fn {name, _value} ->
-      String.downcase(name) in @unallowed_trailing_headers
+      downcase_ascii(name) in @unallowed_trailing_headers
     end)
   end
 end

--- a/lib/mint/core/util.ex
+++ b/lib/mint/core/util.ex
@@ -1,6 +1,51 @@
 defmodule Mint.Core.Util do
   @moduledoc false
 
+  @unallowed_trailing_headers MapSet.new([
+                                "content-encoding",
+                                "content-length",
+                                "content-range",
+                                "content-type",
+                                "trailer",
+                                "transfer-encoding",
+
+                                # Control headers (https://svn.tools.ietf.org/svn/wg/httpbis/specs/rfc7231.html#rfc.section.5.1)
+                                "cache-control",
+                                "expect",
+                                "host",
+                                "max-forwards",
+                                "pragma",
+                                "range",
+                                "te",
+
+                                # Conditionals (https://svn.tools.ietf.org/svn/wg/httpbis/specs/rfc7231.html#rfc.section.5.2)
+                                "if-match",
+                                "if-none-match",
+                                "if-modified-since",
+                                "if-unmodified-since",
+                                "if-range",
+
+                                # Authentication/authorization (https://tools.ietf.org/html/rfc7235#section-5.3)
+                                "authorization",
+                                "proxy-authenticate",
+                                "proxy-authorization",
+                                "www-authenticate",
+
+                                # Cookie management (https://tools.ietf.org/html/rfc6265)
+                                "cookie",
+                                "set-cookie",
+
+                                # Control data (https://svn.tools.ietf.org/svn/wg/httpbis/specs/rfc7231.html#rfc.section.7.1)
+                                "age",
+                                "cache-control",
+                                "expires",
+                                "date",
+                                "location",
+                                "retry-after",
+                                "vary",
+                                "warning"
+                              ])
+
   def inet_opts(transport, socket) do
     with {:ok, opts} <- transport.getopts(socket, [:sndbuf, :recbuf, :buffer]),
          buffer = calculate_buffer(opts),
@@ -47,4 +92,12 @@ defmodule Mint.Core.Util do
   # This should be fixed in a subsequent OTP release.
   def maybe_concat(<<>>, data), do: data
   def maybe_concat(buffer, data) when is_binary(buffer), do: buffer <> data
+
+  def find_unallowed_trailing_header(headers) do
+    Enum.find(headers, fn {name, _value} -> name in @unallowed_trailing_headers end)
+  end
+
+  def remove_unallowed_trailing_headers(headers) do
+    Enum.reject(headers, fn {name, _value} -> name in @unallowed_trailing_headers end)
+  end
 end

--- a/lib/mint/core/util.ex
+++ b/lib/mint/core/util.ex
@@ -98,6 +98,9 @@ defmodule Mint.Core.Util do
   end
 
   def remove_unallowed_trailing_headers(headers) do
-    Enum.reject(headers, fn {name, _value} -> name in @unallowed_trailing_headers end)
+    # TODO: don't downcase here, downcase all headers as soon as we parse them instead.
+    Enum.reject(headers, fn {name, _value} ->
+      String.downcase(name) in @unallowed_trailing_headers
+    end)
   end
 end

--- a/lib/mint/http1.ex
+++ b/lib/mint/http1.ex
@@ -994,4 +994,8 @@ defmodule Mint.HTTP1 do
   def format_error(:trailing_headers_but_not_chunked_encoding) do
     "trailing headers can only be sent when using chunked transfer-encoding"
   end
+
+  def format_error({:unallowed_trailing_header, {name, value}}) do
+    "header #{inspect(name)} (with value #{inspect(value)}) is not allowed as a trailing header"
+  end
 end

--- a/lib/mint/http2.ex
+++ b/lib/mint/http2.ex
@@ -2016,6 +2016,10 @@ defmodule Mint.HTTP2 do
     "can't send more data on this request since it's not streaming"
   end
 
+  def format_error({:unallowed_trailing_header, {name, value}}) do
+    "header #{inspect(name)} (with value #{inspect(value)}) is not allowed as a trailing header"
+  end
+
   def format_error(:missing_status_header) do
     "the :status pseudo-header (which is required in HTTP/2) is missing from the response"
   end

--- a/test/mint/http1/conn_properties_test.exs
+++ b/test/mint/http1/conn_properties_test.exs
@@ -38,7 +38,7 @@ defmodule Mint.HTTP1.PropertiesTest do
 
     response =
       "HTTP/1.1 200 OK\r\ntransfer-encoding: chunked\r\n\r\n" <>
-        "2meta\r\n01\r\n2\r\n23\r\n0meta\r\ntrailer: value\r\n\r\n"
+        "2meta\r\n01\r\n2\r\n23\r\n0meta\r\nmy-trailer: value\r\n\r\n"
 
     check all byte_chunks <- random_chunks(response) do
       {conn, responses} =
@@ -51,7 +51,7 @@ defmodule Mint.HTTP1.PropertiesTest do
       assert [status, headers | rest] = responses
       assert {:status, ^ref, 200} = status
       assert {:headers, ^ref, [{"transfer-encoding", "chunked"}]} = headers
-      assert merge_body_with_trailers(rest, ref) == {"0123", [{"trailer", "value"}]}
+      assert merge_body_with_trailers(rest, ref) == {"0123", [{"my-trailer", "value"}]}
       assert conn.buffer == ""
     end
   end

--- a/test/mint/http1/conn_test.exs
+++ b/test/mint/http1/conn_test.exs
@@ -263,7 +263,6 @@ defmodule Mint.HTTP1Test do
     assert conn.buffer == "XXX"
   end
 
-  @tag :focus
   test "unallowed trailing headers are removed from the trailing headers", %{conn: conn} do
     {:ok, conn, ref} = HTTP1.request(conn, "GET", "/", [], nil)
 
@@ -597,7 +596,6 @@ defmodule Mint.HTTP1Test do
                HTTP1.stream_request_body(conn, ref, {:eof, [{"my-trailer", "value"}]})
     end
 
-    @tag :focus
     test "sending unallowed trailing headers is an error", %{conn: conn} do
       {:ok, conn, ref} = HTTP1.request(conn, "POST", "/", [], :stream)
 

--- a/test/mint/http1/conn_test.exs
+++ b/test/mint/http1/conn_test.exs
@@ -249,7 +249,7 @@ defmodule Mint.HTTP1Test do
 
     response =
       "HTTP/1.1 200 OK\r\ntransfer-encoding: chunked\r\n\r\n" <>
-        "2meta\r\n01\r\n2\r\n23\r\n0meta\r\ntrailer: value\r\n\r\nXXX"
+        "2meta\r\n01\r\n2\r\n23\r\n0meta\r\nmy-trailer: value\r\n\r\nXXX"
 
     assert {:ok, conn, [status, headers, body, trailers, done]} =
              HTTP1.stream(conn, {:tcp, conn.socket, response})
@@ -257,10 +257,31 @@ defmodule Mint.HTTP1Test do
     assert status == {:status, ref, 200}
     assert headers == {:headers, ref, [{"transfer-encoding", "chunked"}]}
     assert body == {:data, ref, "0123"}
-    assert trailers == {:headers, ref, [{"trailer", "value"}]}
+    assert trailers == {:headers, ref, [{"my-trailer", "value"}]}
     assert done == {:done, ref}
 
     assert conn.buffer == "XXX"
+  end
+
+  @tag :focus
+  test "unallowed trailing headers are removed from the trailing headers", %{conn: conn} do
+    {:ok, conn, ref} = HTTP1.request(conn, "GET", "/", [], nil)
+
+    response =
+      "HTTP/1.1 200 OK\r\ntransfer-encoding: chunked\r\n\r\n" <>
+        "2meta\r\n01\r\n2\r\n23\r\n0meta\r\n" <>
+        "my-trailer: value\r\ncontent-type: application/json\r\n\r\n"
+
+    assert {:ok, conn, [status, headers, body, trailers, done]} =
+             HTTP1.stream(conn, {:tcp, conn.socket, response})
+
+    assert status == {:status, ref, 200}
+    assert headers == {:headers, ref, [{"transfer-encoding", "chunked"}]}
+    assert body == {:data, ref, "0123"}
+    assert trailers == {:headers, ref, [{"my-trailer", "value"}]}
+    assert done == {:done, ref}
+
+    assert conn.buffer == ""
   end
 
   test "do not chunk if unknown transfer-encoding", %{conn: conn} do
@@ -574,6 +595,20 @@ defmodule Mint.HTTP1Test do
 
       assert {:error, conn, %HTTPError{reason: :trailing_headers_but_not_chunked_encoding}} =
                HTTP1.stream_request_body(conn, ref, {:eof, [{"my-trailer", "value"}]})
+    end
+
+    @tag :focus
+    test "sending unallowed trailing headers is an error", %{conn: conn} do
+      {:ok, conn, ref} = HTTP1.request(conn, "POST", "/", [], :stream)
+
+      # The Host is an example of an unallowed header. It should be unallowed
+      # regardless of its casing.
+      trailing_headers = [{"my-trailing", "value"}, {"Host", "example.com"}]
+
+      assert {:error, conn, error} =
+               HTTP1.stream_request_body(conn, ref, {:eof, trailing_headers})
+
+      assert %HTTPError{reason: {:unallowed_trailing_header, {"host", "example.com"}}} = error
     end
   end
 


### PR DESCRIPTION
Closes #188.

Now we:

  * error out if the user tries to send an unallowed trailing header (returning a new error)
  * remove all unallowed trailing headers from response headers (for security reasons)