### PR TITLE
Fix architecture example

### DIFF
--- a/pages/Architecture.md
+++ b/pages/Architecture.md
@@ -45,9 +45,13 @@ defmodule ConnectionProcess do
 
   @impl true
   def init({scheme, host, port}) do
-    with {:ok, conn} <- Mint.HTTP.connect(scheme, host, port) do
-      state = %__MODULE__{conn: conn}
-      {:ok, state}
+    case Mint.HTTP.connect(scheme, host, port) do
+      {:ok, conn} ->
+        state = %__MODULE__{conn: conn}
+        {:ok, state}
+
+      {:error, reason} ->
+        {:stop, reason}
     end
   end
 


### PR DESCRIPTION
GenServer’s `init` callback expects `{:stop, reason}` during failures.

Current example returns `{:error, reason}` which logs an inexact error.

```
** (EXIT from #PID<0.182.0>) shell process exited with reason: bad return value: {:error, %Mint.TransportError{reason: :timeout}}
```