### PR TITLE
Add port to host header if it is not the default one for the scheme (HTTP1)

### DIFF
--- a/lib/mint/core/util.ex
+++ b/lib/mint/core/util.ex
@@ -58,6 +58,10 @@ defmodule Mint.Core.Util do
   def scheme_to_transport(:https), do: Mint.Core.Transport.SSL
   def scheme_to_transport(module) when is_atom(module), do: module
 
+  def transport_to_scheme(Mint.Core.Transport.TCP), do: :http
+  def transport_to_scheme(Mint.Core.Transport.SSL), do: :https
+  def transport_to_scheme(atom) when is_atom(atom), do: atom
+
   defp calculate_buffer(opts) do
     Keyword.fetch!(opts, :buffer)
     |> max(Keyword.fetch!(opts, :sndbuf))

--- a/lib/mint/core/util.ex
+++ b/lib/mint/core/util.ex
@@ -58,10 +58,6 @@ defmodule Mint.Core.Util do
   def scheme_to_transport(:https), do: Mint.Core.Transport.SSL
   def scheme_to_transport(module) when is_atom(module), do: module
 
-  def transport_to_scheme(Mint.Core.Transport.TCP), do: :http
-  def transport_to_scheme(Mint.Core.Transport.SSL), do: :https
-  def transport_to_scheme(atom) when is_atom(atom), do: atom
-
   defp calculate_buffer(opts) do
     Keyword.fetch!(opts, :buffer)
     |> max(Keyword.fetch!(opts, :sndbuf))


### PR DESCRIPTION
I basically did the same thing as jmmk did here: #200 but for HTTP1.