### PR TITLE
Deprecate request/4

### DIFF
--- a/lib/mint/http.ex
+++ b/lib/mint/http.ex
@@ -409,7 +409,7 @@ defmodule Mint.HTTP do
   `header_name` and `header_value` being strings. `body` can have one of three
   values:
 
-    * `nil` - no body is sent with the request. This is the default value.
+    * `nil` - no body is sent with the request.
 
     * iodata - the body to send for the request.
 
@@ -442,7 +442,7 @@ defmodule Mint.HTTP do
 
   ## Examples
 
-      Mint.HTTP.request(conn, "GET", "/", _headers = [])
+      Mint.HTTP.request(conn, "GET", "/", _headers = [], _body = nil)
       Mint.HTTP.request(conn, "POST", "/path", [{"content-type", "application/json"}], "{}")
 
   """
@@ -456,8 +456,16 @@ defmodule Mint.HTTP do
         ) ::
           {:ok, t(), Types.request_ref()}
           | {:error, t(), Types.error()}
-  def request(conn, method, path, headers, body \\ nil),
+
+  def request(conn, method, path, headers, body),
     do: conn_module(conn).request(conn, method, path, headers, body)
+
+  # TODO: remove on v1.0.
+  @doc false
+  @deprecated "Use Mint.HTTP.request/5 instead"
+  def request(conn, method, path, headers) do
+    request(conn, method, path, headers, _body = nil)
+  end
 
   @doc """
   Streams a chunk of the request body on the connection or signals the end of the body.

--- a/lib/mint/http1.ex
+++ b/lib/mint/http1.ex
@@ -200,7 +200,7 @@ defmodule Mint.HTTP1 do
   @doc false
   @deprecated "Use Mint.HTTP1.request/5 instead"
   def request(conn, method, path, headers) do
-    request(conn, method, path, headers, nil)
+    request(conn, method, path, headers, _body = nil)
   end
 
   @doc """

--- a/lib/mint/http1.ex
+++ b/lib/mint/http1.ex
@@ -196,12 +196,18 @@ defmodule Mint.HTTP1 do
     state == :open
   end
 
+  # TODO: remove on v1.0.
+  @doc false
+  @deprecated "Use Mint.HTTP1.request/5 instead"
+  def request(conn, method, path, headers) do
+    request(conn, method, path, headers, nil)
+  end
+
   @doc """
   See `Mint.HTTP.request/5`.
 
   In HTTP/1 and HTTP/1.1, you can't open a new request if you're streaming the body of
-  another request. If you try, the error reason `{:error, :request_body_is_streaming}` is
-  returned.
+  another request. If you try, an error will be returned.
   """
   @impl true
   @spec request(
@@ -213,7 +219,7 @@ defmodule Mint.HTTP1 do
         ) ::
           {:ok, t(), Types.request_ref()}
           | {:error, t(), Types.error()}
-  def request(conn, method, path, headers, body \\ nil)
+  def request(conn, method, path, headers, body)
 
   def request(%__MODULE__{state: :closed} = conn, _method, _path, _headers, _body) do
     {:error, conn, wrap_error(:closed)}

--- a/lib/mint/http2.ex
+++ b/lib/mint/http2.ex
@@ -419,6 +419,13 @@ defmodule Mint.HTTP2 do
     end
   end
 
+  # TODO: remove on v1.0.
+  @doc false
+  @deprecated "Use Mint.HTTP2.request/5 instead"
+  def request(conn, method, path, headers) do
+    request(conn, method, path, headers, _body = nil)
+  end
+
   @doc """
   See `Mint.HTTP.request/5`.
 
@@ -449,7 +456,7 @@ defmodule Mint.HTTP2 do
         ) ::
           {:ok, t(), Types.request_ref()}
           | {:error, t(), Types.error()}
-  def request(conn, method, path, headers, body \\ nil)
+  def request(conn, method, path, headers, body)
 
   def request(%Mint.HTTP2{state: :closed} = conn, _method, _path, _headers, _body) do
     {:error, conn, wrap_error(:closed)}

--- a/lib/mint/tunnel_proxy.ex
+++ b/lib/mint/tunnel_proxy.ex
@@ -18,7 +18,7 @@ defmodule Mint.TunnelProxy do
 
     with {:ok, conn} <- HTTP1.connect(proxy_scheme, proxy_hostname, proxy_port, proxy_opts),
          timeout_deadline = timeout_deadline(proxy_opts),
-         {:ok, conn, ref} <- HTTP1.request(conn, "CONNECT", path, []),
+         {:ok, conn, ref} <- HTTP1.request(conn, "CONNECT", path, [], nil),
          :ok <- receive_response(conn, ref, timeout_deadline) do
       {:ok, conn}
     else

--- a/test/mint/http1/conn_test.exs
+++ b/test/mint/http1/conn_test.exs
@@ -306,7 +306,7 @@ defmodule Mint.HTTP1Test do
 
   test "request/5 returns an error if the connection is closed", %{conn: conn} do
     assert {:ok, conn} = HTTP1.close(conn)
-    assert {:error, _conn, %HTTPError{reason: :closed}} = HTTP1.request(conn, "GET", "/", [])
+    assert {:error, _conn, %HTTPError{reason: :closed}} = HTTP1.request(conn, "GET", "/", [], nil)
   end
 
   test "open_request_count/1", %{conn: conn} do

--- a/test/mint/http2/conn_test.exs
+++ b/test/mint/http2/conn_test.exs
@@ -265,12 +265,12 @@ defmodule Mint.HTTP2Test do
                  )
                ])
 
-      assert {:error, %HTTP2{} = conn, error} = HTTP2.request(conn, "GET", "/", [])
+      assert {:error, %HTTP2{} = conn, error} = HTTP2.request(conn, "GET", "/", [], nil)
       assert_http2_error error, :closed_for_writing
 
       assert {:ok, conn} = HTTP2.close(conn)
 
-      assert {:error, %HTTP2{}, error} = HTTP2.request(conn, "GET", "/", [])
+      assert {:error, %HTTP2{}, error} = HTTP2.request(conn, "GET", "/", [], nil)
       assert_http2_error error, :closed
     end
   end
@@ -280,7 +280,7 @@ defmodule Mint.HTTP2Test do
     test "when the client tries to open too many concurrent requests", %{conn: conn} do
       {conn, _ref} = open_request(conn)
 
-      assert {:error, %HTTP2{} = conn, error} = HTTP2.request(conn, "GET", "/", [])
+      assert {:error, %HTTP2{} = conn, error} = HTTP2.request(conn, "GET", "/", [], nil)
       assert_http2_error error, :too_many_concurrent_requests
 
       assert HTTP2.open?(conn)
@@ -426,7 +426,7 @@ defmodule Mint.HTTP2Test do
       # This is an empirical number of headers so that the minimum max frame size (~16kb) fits
       # between 2 and 3 times (so that we can test the behaviour above).
       headers = for i <- 1..400, do: {"a#{i}", String.duplicate("a", 100)}
-      assert {:ok, conn, _ref} = HTTP2.request(conn, "GET", "/", headers)
+      assert {:ok, conn, _ref} = HTTP2.request(conn, "GET", "/", headers, nil)
 
       assert_recv_frames [
         headers(stream_id: stream_id, hbf: hbf1, flags: flags1),
@@ -450,7 +450,7 @@ defmodule Mint.HTTP2Test do
       # With such a low max_header_list_size, even the default :special headers (such as
       # :method or :path) exceed the size.
 
-      assert {:error, %HTTP2{} = conn, error} = HTTP2.request(conn, "GET", "/", [])
+      assert {:error, %HTTP2{} = conn, error} = HTTP2.request(conn, "GET", "/", [], nil)
 
       assert_http2_error error, {:max_header_list_size_exceeded, _, 20}
 

--- a/test/mint/http2/integration_test.exs
+++ b/test/mint/http2/integration_test.exs
@@ -22,7 +22,7 @@ defmodule HTTP2.IntegrationTest do
     @describetag connect: {"http2.golang.org", 443}
 
     test "GET /reqinfo", %{conn: conn} do
-      assert {:ok, %HTTP2{} = conn, req_id} = HTTP2.request(conn, "GET", "/reqinfo", [])
+      assert {:ok, %HTTP2{} = conn, req_id} = HTTP2.request(conn, "GET", "/reqinfo", [], nil)
 
       assert {:ok, %HTTP2{} = conn, responses} = receive_stream(conn)
 
@@ -41,7 +41,7 @@ defmodule HTTP2.IntegrationTest do
     end
 
     test "GET /clockstream", %{conn: conn} do
-      assert {:ok, %HTTP2{} = conn, req_id} = HTTP2.request(conn, "GET", "/clockstream", [])
+      assert {:ok, %HTTP2{} = conn, req_id} = HTTP2.request(conn, "GET", "/clockstream", [], nil)
 
       assert {:ok, %HTTP2{} = conn, responses} = stream_messages_until_response(conn)
       assert [{:status, ^req_id, 200}, {:headers, ^req_id, _headers} | rest] = responses
@@ -89,7 +89,7 @@ defmodule HTTP2.IntegrationTest do
     end
 
     test "GET /file/gopher.png", %{conn: conn} do
-      assert {:ok, %HTTP2{} = conn, ref} = HTTP2.request(conn, "GET", "/file/gopher.png", [])
+      assert {:ok, %HTTP2{} = conn, ref} = HTTP2.request(conn, "GET", "/file/gopher.png", [], nil)
       assert {:ok, %HTTP2{} = conn, responses} = receive_stream(conn)
 
       assert [
@@ -118,7 +118,7 @@ defmodule HTTP2.IntegrationTest do
     end
 
     test "GET /serverpush", %{conn: conn} do
-      assert {:ok, %HTTP2{} = conn, req_id} = HTTP2.request(conn, "GET", "/serverpush", [])
+      assert {:ok, %HTTP2{} = conn, req_id} = HTTP2.request(conn, "GET", "/serverpush", [], nil)
       assert {:ok, %HTTP2{} = _conn, responses} = receive_stream(conn)
 
       # TODO: improve this test by improving receive_stream/1.
@@ -142,7 +142,7 @@ defmodule HTTP2.IntegrationTest do
     end
 
     test "GET /", %{conn: conn} do
-      assert {:ok, %HTTP2{} = conn, ref} = HTTP2.request(conn, "GET", "/", [])
+      assert {:ok, %HTTP2{} = conn, ref} = HTTP2.request(conn, "GET", "/", [], nil)
 
       assert {:ok, %HTTP2{} = conn, responses} = receive_stream(conn)
 
@@ -167,7 +167,7 @@ defmodule HTTP2.IntegrationTest do
     end
 
     test "GET /", %{conn: conn} do
-      assert {:ok, %HTTP2{} = conn, ref} = HTTP2.request(conn, "GET", "/", [])
+      assert {:ok, %HTTP2{} = conn, ref} = HTTP2.request(conn, "GET", "/", [], nil)
 
       assert {:ok, %HTTP2{} = conn, responses} = receive_stream(conn)
 
@@ -193,7 +193,7 @@ defmodule HTTP2.IntegrationTest do
     end
 
     test "GET /", %{conn: conn} do
-      assert {:ok, %HTTP2{} = conn, ref} = HTTP2.request(conn, "GET", "/httpbin/", [])
+      assert {:ok, %HTTP2{} = conn, ref} = HTTP2.request(conn, "GET", "/httpbin/", [], nil)
 
       assert {:ok, %HTTP2{} = conn, responses} = receive_stream(conn)
 
@@ -215,7 +215,7 @@ defmodule HTTP2.IntegrationTest do
       # Using non-downcased header meant that HPACK wouldn't find it in the
       # static built-in headers table and so it wouldn't encode it correctly.
       headers = [{"If-Modified-Since", "Wed, 26 May 2019 07:43:40 GMT"}]
-      assert {:ok, %HTTP2{} = conn, ref} = HTTP2.request(conn, "GET", "/feed/", headers)
+      assert {:ok, %HTTP2{} = conn, ref} = HTTP2.request(conn, "GET", "/feed/", headers, nil)
 
       assert {:ok, %HTTP2{} = conn, responses} = receive_stream(conn)
 


### PR DESCRIPTION
We want to enforce the body so that in the future we can add options as the sixth argument.